### PR TITLE
Added several settings/options to hob.

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,9 +247,40 @@ Wash program selection and options (half load, hygiene plus, extra dry, extra ri
 
 Program options including temperature, spin speed, prewash, rinse plus, gentle cycle, and hygienic steam; iDos automatic dosing (levels 1 & 2); drum light and door ring LED control (brightness and color mode); anti-wrinkle guard; maintenance reminders (drum clean, lint filter full); condensate container alert (dryer).
 
-### Oven / Hob / Hood
+### Oven
 
-Oven current and setpoint temperature, meat probe temperature and plugged-in status, heating mode selection, fast preheat, sabbath mode, convection conversion, dim display on standby, clock display (analogue/digital); hood fan speed control, ambient and work lighting, automatic shutoff delay, interval ventilation, grease and carbon filter saturation sensors and one-tap reset buttons; hob ventilation level.
+Oven current and setpoint temperature, meat probe temperature and plugged-in status, heating mode selection, fast preheat, sabbath mode, convection conversion, dim display on standby, clock display (analogue/digital)
+
+### Hob
+
+- Automatic timer
+  - Time (minutes) after which a zone turns off automatically
+- Automatic keylock
+  - Defines if keylock (childlock) is turned on automatically, manually or turned off completely
+- BridgeZoneMode
+  - When turning on hob this indicates if some zone (pre defined) are joined or split
+- EnergyConsumptionIndication
+  - Indicates if energy consumption (kWh) shall be displayed after hob is turned off
+- PowerManagement
+  - Maximum power drain (off or 1000W up to 9000W; 500W steps)
+- BuzzerBeepLevel
+  - Which signal types shall be played
+- EndTimerSignalduration
+  - Signal duration after timer runs out
+- Ventilation level
+- Those are only available if paired with a hood:
+  - HoodAutomaticLightOff
+    - When hob is turned off then also turn off hood light
+  - HoodAutomaticLightOn
+    - When hob is turned on then also turn on hood light
+  - HoodAutomaticStart
+    - When hob is turned on then also turn on hood fan
+  - HoodAfterRun
+    - When hob is turned off then also keep hood fan running (or not)
+
+### Hood
+
+Hood fan speed control, ambient and work lighting, automatic shutoff delay, interval ventilation, grease and carbon filter saturation sensors and one-tap reset buttons
 
 ### Coffee Maker
 

--- a/custom_components/homeconnect_ws/entity_descriptions/cooking.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/cooking.py
@@ -644,13 +644,8 @@ COOKING_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             has_state_translation=True,
             entity_category=EntityCategory.CONFIG,
         ),
-        # Disabled because setting value results in 'Error response from Appliance: ReadRequest NotAvailable'.
-        #HCSelectEntityDescription(
-        #    key="select_hob_power_level",
-        #    entity="Cooking.Hob.Option.PowerLevel",
-        #    has_state_translation=True,
-        #    entity_category=EntityCategory.CONFIG,
-        #),
+        # Cooking.Hob.Option.PowerLevel isn't exposed here - setting it
+        # returns 'Error response from Appliance: ReadRequest NotAvailable'.
         HCSelectEntityDescription(
             key="select_hob_hood_automatic_light_off",
             entity="Cooking.Hob.Setting.HoodAutomaticLightOff",

--- a/custom_components/homeconnect_ws/entity_descriptions/cooking.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/cooking.py
@@ -553,6 +553,7 @@ COOKING_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             key="number_hob_automatic_timer",
             entity="Cooking.Hob.Setting.AutomaticTimer",
             entity_category=EntityCategory.CONFIG,
+            native_max_value=99,  # matching the Home Connect App's limit
             mode=NumberMode.AUTO,
         ),
         HCNumberEntityDescription(
@@ -638,26 +639,8 @@ COOKING_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             has_state_translation=True,
             entity_category=EntityCategory.CONFIG,
         ),
-        HCSelectEntityDescription(
-            key="select_hob_energy_consumption_indication",
-            entity="Cooking.Hob.Setting.EnergyConsumptionIndication",
-            has_state_translation=True,
-            entity_category=EntityCategory.CONFIG,
-        ),
         # Cooking.Hob.Option.PowerLevel isn't exposed here - setting it
         # returns 'Error response from Appliance: ReadRequest NotAvailable'.
-        HCSelectEntityDescription(
-            key="select_hob_hood_automatic_light_off",
-            entity="Cooking.Hob.Setting.HoodAutomaticLightOff",
-            has_state_translation=True,
-            entity_category=EntityCategory.CONFIG,
-        ),
-        HCSelectEntityDescription(
-            key="select_hob_hood_automatic_light_on",
-            entity="Cooking.Hob.Setting.HoodAutomaticLightOn",
-            has_state_translation=True,
-            entity_category=EntityCategory.CONFIG,
-        ),
         HCSelectEntityDescription(
             key="select_hob_hood_automatic_start",
             entity="Cooking.Hob.Setting.HoodAutomaticStart",
@@ -723,6 +706,27 @@ COOKING_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
         ),
     ],
     "switch": [
+        HCSwitchEntityDescription(
+            key="switch_hob_energy_consumption_indication",
+            entity="Cooking.Hob.Setting.EnergyConsumptionIndication",
+            device_class=SwitchDeviceClass.SWITCH,
+            value_mapping=("IndicationOn", "IndicationOff"),
+            entity_category=EntityCategory.CONFIG,
+        ),
+        HCSwitchEntityDescription(
+            key="switch_hob_hood_automatic_light_off",
+            entity="Cooking.Hob.Setting.HoodAutomaticLightOff",
+            device_class=SwitchDeviceClass.SWITCH,
+            value_mapping=("On", "Off"),
+            entity_category=EntityCategory.CONFIG,
+        ),
+        HCSwitchEntityDescription(
+            key="switch_hob_hood_automatic_light_on",
+            entity="Cooking.Hob.Setting.HoodAutomaticLightOn",
+            device_class=SwitchDeviceClass.SWITCH,
+            value_mapping=("On", "Off"),
+            entity_category=EntityCategory.CONFIG,
+        ),
         HCSwitchEntityDescription(
             key="switch_oven_fast_pre_heat",
             entity="Cooking.Oven.Option.FastPreHeat",

--- a/custom_components/homeconnect_ws/entity_descriptions/cooking.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/cooking.py
@@ -546,6 +546,12 @@ COOKING_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             mode=NumberMode.AUTO,
         ),
         HCNumberEntityDescription(
+            key="number_hob_automatic_timer",
+            entity="Cooking.Hob.Setting.AutomaticTimer",
+            entity_category=EntityCategory.CONFIG,
+            mode=NumberMode.AUTO,
+        ),
+        HCNumberEntityDescription(
             key="number_hood_interval_off",
             entity="Cooking.Hood.Setting.IntervalTimeOn",
             native_unit_of_measurement=UnitOfTime.SECONDS,
@@ -617,9 +623,53 @@ COOKING_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             entity_category=EntityCategory.CONFIG,
         ),
         HCSelectEntityDescription(
-            key="select_hood_interval_stage",
-            entity="Cooking.Hood.Setting.IntervalStage",
+            key="select_hob_automatic_keylock",
+            entity="Cooking.Hob.Setting.AutomaticKeyLock",
             has_state_translation=True,
+            entity_category=EntityCategory.CONFIG,
+        ),
+        HCSelectEntityDescription(
+            key="select_hob_bridge_zone_mode",
+            entity="Cooking.Hob.Setting.BridgeZoneMode",
+            has_state_translation=True,
+            entity_category=EntityCategory.CONFIG,
+        ),
+        HCSelectEntityDescription(
+            key="select_hob_energy_consumption_indication",
+            entity="Cooking.Hob.Setting.EnergyConsumptionIndication",
+            has_state_translation=True,
+            entity_category=EntityCategory.CONFIG,
+        ),
+        # Disabled because setting value results in 'Error response from Appliance: ReadRequest NotAvailable'.
+        #HCSelectEntityDescription(
+        #    key="select_hob_power_level",
+        #    entity="Cooking.Hob.Option.PowerLevel",
+        #    has_state_translation=True,
+        #    entity_category=EntityCategory.CONFIG,
+        #),
+        HCSelectEntityDescription(
+            key="select_hob_hood_automatic_light_off",
+            entity="Cooking.Hob.Setting.HoodAutomaticLightOff",
+            has_state_translation=True,
+            entity_category=EntityCategory.CONFIG,
+        ),
+        HCSelectEntityDescription(
+            key="select_hob_hood_automatic_light_on",
+            entity="Cooking.Hob.Setting.HoodAutomaticLightOn",
+            has_state_translation=True,
+            entity_category=EntityCategory.CONFIG,
+        ),
+        HCSelectEntityDescription(
+            key="select_hob_hood_automatic_start",
+            entity="Cooking.Hob.Setting.HoodAutomaticStart",
+            has_state_translation=True,
+            entity_category=EntityCategory.CONFIG,
+        ),
+        HCSelectEntityDescription(
+            key="select_hob_hood_after_run",
+            entity="Cooking.Hob.Setting.HoodAfterRun",
+            has_state_translation=True,
+            entity_category=EntityCategory.CONFIG,
         ),
         HCSelectEntityDescription(
             key="select_hob_ventilation",
@@ -630,6 +680,29 @@ COOKING_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
         HCSelectEntityDescription(
             key="select_hob_delaye_shutoff_stage",
             entity="Cooking.Hood.Setting.DelayedShutOffStage",
+            has_state_translation=True,
+        ),
+        HCSelectEntityDescription(
+            key="select_hob_power_management",
+            entity="Cooking.Hob.Setting.PowerManagement",
+            has_state_translation=True,
+            entity_category=EntityCategory.CONFIG,
+        ),
+        HCSelectEntityDescription(
+            key="select_hob_buzzer_beep_level",
+            entity="Cooking.Hob.Setting.BuzzerBeepLevel",
+            has_state_translation=True,
+            entity_category=EntityCategory.CONFIG,
+        ),
+        HCSelectEntityDescription(
+            key="select_hob_end_timer_signal_duration",
+            entity="Cooking.Hob.Setting.EndTimerSignalduration",
+            has_state_translation=True,
+            entity_category=EntityCategory.CONFIG,
+        ),
+        HCSelectEntityDescription(
+            key="select_hood_interval_stage",
+            entity="Cooking.Hood.Setting.IntervalStage",
             has_state_translation=True,
         ),
         HCSelectEntityDescription(

--- a/custom_components/homeconnect_ws/icons.json
+++ b/custom_components/homeconnect_ws/icons.json
@@ -393,7 +393,31 @@
             },
             "select_refrigerator_door_assistant_freezer_trigger": {
                 "default": "mdi:door"
-            }
+            },
+			"select_hob_automatic_keylock": {
+				"default": "mdi:lock-reset"
+			},
+			"select_hob_energy_consumption_indication": {
+				"default": "mdi:transmission-tower"
+			},
+			"select_hob_bridge_zone_mode": {
+				"default": "mdi:arrow-split-horizontal"
+			},
+			"select_hob_hood_automatic_light_off": {
+				"default": "mdi:lightbulb-auto-outline"
+			},
+			"select_hob_hood_automatic_light_on": {
+				"default": "mdi:lightbulb-auto"
+			},
+			"select_hob_hood_automatic_start": {
+				"default": "mdi:fan-auto"
+			},
+			"select_hob_hood_after_run": {
+				"default": "mdi:fan-off"
+			},
+			"select_hob_power_management": {
+				"default": "mdi:flash"
+			}
         },
         "button": {
             "button_abort_program": {

--- a/custom_components/homeconnect_ws/icons.json
+++ b/custom_components/homeconnect_ws/icons.json
@@ -77,6 +77,15 @@
 			"switch_oven_display_brand_logo": {
 				"default": "mdi:trademark"
 			},
+			"switch_hob_energy_consumption_indication": {
+				"default": "mdi:transmission-tower"
+			},
+			"switch_hob_hood_automatic_light_off": {
+				"default": "mdi:lightbulb-auto-outline"
+			},
+			"switch_hob_hood_automatic_light_on": {
+				"default": "mdi:lightbulb-auto"
+			},
             "switch_dishwasher_sanitation": {
                 "default": "mdi:bacteria-outline"
             },
@@ -397,17 +406,8 @@
 			"select_hob_automatic_keylock": {
 				"default": "mdi:lock-reset"
 			},
-			"select_hob_energy_consumption_indication": {
-				"default": "mdi:transmission-tower"
-			},
 			"select_hob_bridge_zone_mode": {
 				"default": "mdi:arrow-split-horizontal"
-			},
-			"select_hob_hood_automatic_light_off": {
-				"default": "mdi:lightbulb-auto-outline"
-			},
-			"select_hob_hood_automatic_light_on": {
-				"default": "mdi:lightbulb-auto"
 			},
 			"select_hob_hood_automatic_start": {
 				"default": "mdi:fan-auto"

--- a/custom_components/homeconnect_ws/translations/de.json
+++ b/custom_components/homeconnect_ws/translations/de.json
@@ -2492,9 +2492,9 @@
         }
       },
       "select_hob_energy_consumption_indication": {
-        "name": "Energy Consumption Indication",
+        "name": "Energieverbrauchsanzeige",
         "state": {
-          "indicationoff": "Vergergen",
+          "indicationoff": "Verbergen",
           "indicationon": "Anzeigen"
         }
       },
@@ -2540,7 +2540,7 @@
         }
       },
       "select_hob_power_management": {
-        "name": "Energieverbrauchsanzeige"
+        "name": "Maximale Leistungsaufnahme"
       },
       "select_hob_buzzer_beep_level": {
         "name": "Signaltöne",

--- a/custom_components/homeconnect_ws/translations/de.json
+++ b/custom_components/homeconnect_ws/translations/de.json
@@ -2474,14 +2474,76 @@
           "high": "Hoch"
         }
       },
-      "select_hood_interval_stage": {
-        "name": "Intervallstufe",
+      "select_hob_automatic_keylock": {
+        "name": "Automatische Tastenspeere",
         "state": {
-          "fanoff": "Aus",
-          "fanstage01": "1",
-          "fanstage02": "2",
-          "fanstage03": "3"
+          "deactivated": "Manuel",
+          "activated": "Automatisch",
+          "keylockfunctiondeactivated": "Deaktiviert"
         }
+      },
+      "select_hob_energy_consumption_indication": {
+        "name": "Energy Consumption Indication",
+        "state": {
+          "indicationoff": "Vergergen",
+          "indicationon": "Anzeigen"
+        }
+      },
+      "select_hob_bridge_zone_mode": {
+        "name": "Vario Induktion",
+        "state": {
+          "splitmode": "Getrennt",
+          "joinmode": "Zusammengeschaltet"
+        }
+      },
+      "select_hob_power_level": {
+        "name": "Power Level"
+      },
+      "select_hob_hood_automatic_light_off": {
+        "name": "Dunstabzugshaube Licht Aus Automatik",
+        "state": {
+          "off": "Aus",
+          "on": "An"
+        }
+      },
+      "select_hob_hood_automatic_light_on": {
+        "name": "Dunstabzugshaube Licht An Automatik",
+        "state": {
+          "off": "Aus",
+          "on": "An"
+        }
+      },
+      "select_hob_hood_automatic_start": {
+        "name": "Dunstabzugshaube Lüftersteuerung",
+        "state": {
+          "off": "Aus",
+          "automaticmode": "Automatisch",
+          "manualmode": "Manuel"
+        }
+      },
+      "select_hob_hood_after_run": {
+        "name": "Dunstabzugshaube Lüfternachlauf",
+        "state": {
+          "off": "Aus",
+          "automaticmode": "Automatisch",
+          "manualmode": "Manuel",
+		  "donothing": "Unverändert"
+        }
+      },
+      "select_hob_power_management": {
+        "name": "Energieverbrauchsanzeige"
+      },
+      "select_hob_buzzer_beep_level": {
+        "name": "Signaltöne",
+        "state": {
+          "alloff": "Alle aus",
+		  "acknowledgeoff": "Tastentöne aus",
+		  "warningmaloff": "Fehlbedienungssignale aus",
+		  "allactive": "Alle an"
+        }
+      },
+      "select_hob_end_timer_signal_duration": {
+        "name": "Signaldauer"
       },
       "select_hob_delaye_shutoff_stage": {
         "name": "Verzögerte Abschaltstufe",
@@ -2497,6 +2559,15 @@
         "state": {
           "celsius": "Celsius",
           "fahrenheit": "Fahrenheit"
+        }
+      },
+      "select_hood_interval_stage": {
+        "name": "Intervallstufe",
+        "state": {
+          "fanoff": "Aus",
+          "fanstage01": "1",
+          "fanstage02": "2",
+          "fanstage03": "3"
         }
       },
       "select_hood_carbon_filter_type": {
@@ -2570,6 +2641,9 @@
       },
       "number_oven_display_brightness": {
         "name": "Display Helligkeit"
+      },
+      "number_hob_automatic_timer": {
+        "name": "Automatischer Timer"
       },
       "number_start_in": {
         "name": "Starten in"

--- a/custom_components/homeconnect_ws/translations/de.json
+++ b/custom_components/homeconnect_ws/translations/de.json
@@ -146,6 +146,15 @@
       "switch_oven_display_brand_logo": {
         "name": "Markenlogo anzeigen"
       },
+      "switch_hob_energy_consumption_indication": {
+        "name": "Energieverbrauchsanzeige"
+      },
+      "switch_hob_hood_automatic_light_off": {
+        "name": "Dunstabzugshaube Licht Aus Automatik"
+      },
+      "switch_hob_hood_automatic_light_on": {
+        "name": "Dunstabzugshaube Licht An Automatik"
+      },
       "switch_zeolite_dry": {
         "name": "CrystalDry"
       },
@@ -2488,13 +2497,6 @@
           "keylockfunctiondeactivated": "Deaktiviert"
         }
       },
-      "select_hob_energy_consumption_indication": {
-        "name": "Energieverbrauchsanzeige",
-        "state": {
-          "indicationoff": "Verbergen",
-          "indicationon": "Anzeigen"
-        }
-      },
       "select_hob_bridge_zone_mode": {
         "name": "Vario Induktion",
         "state": {
@@ -2504,20 +2506,6 @@
       },
       "select_hob_power_level": {
         "name": "Leistungsstufe"
-      },
-      "select_hob_hood_automatic_light_off": {
-        "name": "Dunstabzugshaube Licht Aus Automatik",
-        "state": {
-          "off": "Aus",
-          "on": "An"
-        }
-      },
-      "select_hob_hood_automatic_light_on": {
-        "name": "Dunstabzugshaube Licht An Automatik",
-        "state": {
-          "off": "Aus",
-          "on": "An"
-        }
       },
       "select_hob_hood_automatic_start": {
         "name": "Dunstabzugshaube Lüftersteuerung",

--- a/custom_components/homeconnect_ws/translations/de.json
+++ b/custom_components/homeconnect_ws/translations/de.json
@@ -2503,7 +2503,7 @@
         }
       },
       "select_hob_power_level": {
-        "name": "Power Level"
+        "name": "Leistungsstufe"
       },
       "select_hob_hood_automatic_light_off": {
         "name": "Dunstabzugshaube Licht Aus Automatik",

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -246,6 +246,15 @@
       "switch_oven_display_brand_logo": {
         "name": "Display brand logo"
       },
+      "switch_hob_energy_consumption_indication": {
+        "name": "Energy Consumption Indication"
+      },
+      "switch_hob_hood_automatic_light_off": {
+        "name": "Hood Automatic Light Off"
+      },
+      "switch_hob_hood_automatic_light_on": {
+        "name": "Hood Automatic Light On"
+      },
       "switch_refrigerator_sabbath_mode": {
         "name": "Sabbath mode"
       },
@@ -3583,13 +3592,6 @@
           "keylockfunctiondeactivated": "Deactivated"
         }
       },
-      "select_hob_energy_consumption_indication": {
-        "name": "Energy Consumption Indication",
-        "state": {
-          "indicationoff": "Hide",
-          "indicationon": "Show"
-        }
-      },
       "select_hob_bridge_zone_mode": {
         "name": "Vario Induction",
         "state": {
@@ -3599,20 +3601,6 @@
       },
       "select_hob_power_level": {
         "name": "Power Level"
-      },
-      "select_hob_hood_automatic_light_off": {
-        "name": "Hood Automatic Light Off",
-        "state": {
-          "off": "Off",
-          "on": "On"
-        }
-      },
-      "select_hob_hood_automatic_light_on": {
-        "name": "Hood Automatic Light On",
-        "state": {
-          "off": "Off",
-          "on": "On"
-        }
       },
       "select_hob_hood_automatic_start": {
         "name": "Hood Automatic Start",

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -3569,15 +3569,76 @@
           "high": "High"
         }
       },
-      "select_hood_interval_stage": {
-        "name": "Interval stage",
+      "select_hob_automatic_keylock": {
+        "name": "Automatic Keylock",
         "state": {
-          "fanoff": "Off",
-          "fanstage01": "1",
-          "fanstage02": "2",
-          "fanstage03": "3",
-          "fanstage04": "4"
+          "deactivated": "Manual",
+          "activated": "Automatic",
+          "keylockfunctiondeactivated": "Deactivated"
         }
+      },
+      "select_hob_energy_consumption_indication": {
+        "name": "Energy Consumption Indication",
+        "state": {
+          "indicationoff": "Hide",
+          "indicationon": "Show"
+        }
+      },
+      "select_hob_bridge_zone_mode": {
+        "name": "Vario Induction",
+        "state": {
+          "splitmode": "Split",
+          "joinmode": "Joined"
+        }
+      },
+      "select_hob_power_level": {
+        "name": "Power Level"
+      },
+      "select_hob_hood_automatic_light_off": {
+        "name": "Hood Automatic Light Off",
+        "state": {
+          "off": "Off",
+          "on": "On"
+        }
+      },
+      "select_hob_hood_automatic_light_on": {
+        "name": "Hood Automatic Light On",
+        "state": {
+          "off": "Off",
+          "on": "On"
+        }
+      },
+      "select_hob_hood_automatic_start": {
+        "name": "Hood Automatic Start",
+        "state": {
+          "off": "Off",
+          "automaticmode": "Automatic",
+          "manualmode": "Manual"
+        }
+      },
+      "select_hob_hood_after_run": {
+        "name": "Hood After Run",
+        "state": {
+          "off": "Off",
+          "automaticmode": "Automatic",
+          "manualmode": "Manual",
+		  "donothing": "Unchanged"
+        }
+      },
+      "select_hob_power_management": {
+        "name": "Power Management"
+      },
+      "select_hob_buzzer_beep_level": {
+        "name": "Buzzer Beep Level",
+        "state": {
+          "alloff": "All off",
+		  "acknowledgeoff": "Button tones off",
+		  "warningmaloff": "Warnings off",
+		  "allactive": "All active"
+        }
+      },
+      "select_hob_end_timer_signal_duration": {
+        "name": "End Timer Signal Duration"
       },
       "select_hob_delaye_shutoff_stage": {
         "name": "Delayed ShutOff Stage",
@@ -3594,6 +3655,16 @@
         "state": {
           "celsius": "Celsius",
           "fahrenheit": "Fahrenheit"
+        }
+      },
+      "select_hood_interval_stage": {
+        "name": "Interval stage",
+        "state": {
+          "fanoff": "Off",
+          "fanstage01": "1",
+          "fanstage02": "2",
+          "fanstage03": "3",
+          "fanstage04": "4"
         }
       },
       "select_hood_carbon_filter_type": {
@@ -3676,6 +3747,9 @@
       },
       "number_oven_display_brightness": {
         "name": "Display brightness"
+      },
+      "number_hob_automatic_timer": {
+        "name": "Automatic Timer"
       },
       "number_hood_interval_off": {
         "name": "Interval time off"

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -3635,7 +3635,7 @@
         }
       },
       "select_hob_power_management": {
-        "name": "Power Management"
+        "name": "Maximum power consumption"
       },
       "select_hob_buzzer_beep_level": {
         "name": "Buzzer Beep Level",

--- a/custom_components/homeconnect_ws/translations/fr.json
+++ b/custom_components/homeconnect_ws/translations/fr.json
@@ -1768,14 +1768,76 @@
           "highforce": "High"
         }
       },
-      "select_hood_interval_stage": {
-        "name": "Interval stage",
+      "select_hob_automatic_keylock": {
+        "name": "Verrouillage automatique",
         "state": {
-          "fanoff": "Désactivé",
-          "fanstage01": "1",
-          "fanstage02": "2",
-          "fanstage03": "3"
+          "deactivated": "Manuel",
+          "activated": "Automatique",
+          "keylockfunctiondeactivated": "Désactivé"
         }
+      },
+      "select_hob_energy_consumption_indication": {
+        "name": "Indication de consommation d'énergie",
+        "state": {
+          "indicationoff": "Masquer",
+          "indicationon": "Afficher"
+        }
+      },
+      "select_hob_bridge_zone_mode": {
+        "name": "VarioInduction",
+        "state": {
+          "splitmode": "Separer",
+          "joinmode": "Connecté"
+        }
+      },
+      "select_hob_power_level": {
+        "name": "Niveau de puissance"
+      },
+      "select_hob_hood_automatic_light_off": {
+        "name": "Extinction automatique de la lumière de la hotte",
+        "state": {
+          "off": "Désactivé",
+          "on": "Activé"
+        }
+      },
+      "select_hob_hood_automatic_light_on": {
+        "name": "Allumage automatique de la lumière de la hotte",
+        "state": {
+          "off": "Désactivé",
+          "on": "Activé"
+        }
+      },
+      "select_hob_hood_automatic_start": {
+        "name": "Démarrage automatique de la hotte",
+        "state": {
+          "off": "Désactivé",
+          "automaticmode": "Automatique",
+          "manualmode": "Manuel"
+        }
+      },
+      "select_hob_hood_after_run": {
+        "name": "Post-fonctionnement de la hotte",
+        "state": {
+          "off": "Désactivé",
+          "automaticmode": "Automatique",
+          "manualmode": "Manuel",
+		  "donothing": "Inchangé"
+        }
+      },
+      "select_hob_power_management": {
+        "name": "Gestion de la puissance"
+      },
+      "select_hob_buzzer_beep_level": {
+        "name": "Niveau du signal sonore",
+        "state": {
+          "alloff": "Tout éteindre",
+		  "acknowledgeoff": "Bip touches désactivés",
+		  "warningmaloff": "Alertes désactivées",
+		  "allactive": "Tout actif"
+        }
+      },
+      "select_hob_end_timer_signal_duration": {
+        "name": "End Timer Signal duration"
       },
       "select_hob_delaye_shutoff_stage": {
         "name": "Delayed ShutOff Stage",
@@ -1791,6 +1853,15 @@
         "state": {
           "celsius": "Celsius",
           "fahrenheit": "Fahrenheit"
+        }
+      },
+      "select_hood_interval_stage": {
+        "name": "Interval stage",
+        "state": {
+          "fanoff": "Désactivé",
+          "fanstage01": "1",
+          "fanstage02": "2",
+          "fanstage03": "3"
         }
       },
       "select_hood_carbon_filter_type": {
@@ -1867,6 +1938,9 @@
       },
       "number_oven_display_brightness": {
         "name": "Luminosité de l'affichage"
+      },
+      "number_hob_automatic_timer": {
+        "name": "Minuteur automatique"
       },
       "number_hood_interval_off": {
         "name": "Interval time off"

--- a/custom_components/homeconnect_ws/translations/fr.json
+++ b/custom_components/homeconnect_ws/translations/fr.json
@@ -1843,7 +1843,7 @@
         }
       },
       "select_hob_end_timer_signal_duration": {
-        "name": "End Timer Signal duration"
+        "name": "Durée du signal de fin de minuterie"
       },
       "select_hob_delaye_shutoff_stage": {
         "name": "Delayed ShutOff Stage",

--- a/custom_components/homeconnect_ws/translations/fr.json
+++ b/custom_components/homeconnect_ws/translations/fr.json
@@ -185,6 +185,15 @@
       "switch_oven_display_brand_logo": {
         "name": "Afficher le logo de la marque"
       },
+      "switch_hob_energy_consumption_indication": {
+        "name": "Indication de consommation d'énergie"
+      },
+      "switch_hob_hood_automatic_light_off": {
+        "name": "Extinction automatique de la lumière de la hotte"
+      },
+      "switch_hob_hood_automatic_light_on": {
+        "name": "Allumage automatique de la lumière de la hotte"
+      },
       "switch_refrigerator_sabbath_mode": {
         "name": "Mode Sabbath"
       },
@@ -1782,13 +1791,6 @@
           "keylockfunctiondeactivated": "Désactivé"
         }
       },
-      "select_hob_energy_consumption_indication": {
-        "name": "Indication de consommation d'énergie",
-        "state": {
-          "indicationoff": "Masquer",
-          "indicationon": "Afficher"
-        }
-      },
       "select_hob_bridge_zone_mode": {
         "name": "VarioInduction",
         "state": {
@@ -1798,20 +1800,6 @@
       },
       "select_hob_power_level": {
         "name": "Niveau de puissance"
-      },
-      "select_hob_hood_automatic_light_off": {
-        "name": "Extinction automatique de la lumière de la hotte",
-        "state": {
-          "off": "Désactivé",
-          "on": "Activé"
-        }
-      },
-      "select_hob_hood_automatic_light_on": {
-        "name": "Allumage automatique de la lumière de la hotte",
-        "state": {
-          "off": "Désactivé",
-          "on": "Activé"
-        }
       },
       "select_hob_hood_automatic_start": {
         "name": "Démarrage automatique de la hotte",

--- a/custom_components/homeconnect_ws/translations/fr.json
+++ b/custom_components/homeconnect_ws/translations/fr.json
@@ -1834,7 +1834,7 @@
         }
       },
       "select_hob_power_management": {
-        "name": "Gestion de la puissance"
+        "name": "Puissance maximale absorbée"
       },
       "select_hob_buzzer_beep_level": {
         "name": "Niveau du signal sonore",

--- a/custom_components/homeconnect_ws/translations/it.json
+++ b/custom_components/homeconnect_ws/translations/it.json
@@ -178,6 +178,15 @@
       },
       "switch_oven_display_brand_logo": {
         "name": "Visualizza il logo del brand"
+      },
+      "switch_hob_energy_consumption_indication": {
+        "name": "Indicazione del consumo energetico"
+      },
+      "switch_hob_hood_automatic_light_off": {
+        "name": "Spegnimento automatico luce cappa"
+      },
+      "switch_hob_hood_automatic_light_on": {
+        "name": "Accensione automatica luce cappa"
       }
     },
     "binary_sensor": {
@@ -1404,13 +1413,6 @@
           "keylockfunctiondeactivated": "Disattivato"
         }
       },
-      "select_hob_energy_consumption_indication": {
-        "name": "Indicazione del consumo energetico",
-        "state": {
-          "indicationoff": "Nascondi",
-          "indicationon": "Mostra"
-        }
-      },
       "select_hob_bridge_zone_mode": {
         "name": "VarioInduzione",
         "state": {
@@ -1420,20 +1422,6 @@
       },
       "select_hob_power_level": {
         "name": "Livello di potenza"
-      },
-      "select_hob_hood_automatic_light_off": {
-        "name": "Spegnimento automatico luce cappa",
-        "state": {
-          "off": "Spento",
-          "on": "Acceso"
-        }
-      },
-      "select_hob_hood_automatic_light_on": {
-        "name": "Accensione automatica luce cappa",
-        "state": {
-          "off": "Spento",
-          "on": "Acceso"
-        }
       },
       "select_hob_hood_automatic_start": {
         "name": "Avvio automatico cappa",

--- a/custom_components/homeconnect_ws/translations/it.json
+++ b/custom_components/homeconnect_ws/translations/it.json
@@ -1465,7 +1465,7 @@
         }
       },
       "select_hob_end_timer_signal_duration": {
-        "name": "End Timer Signal duration"
+        "name": "Durata del segnale di fine timer"
       }
     },
     "button": {

--- a/custom_components/homeconnect_ws/translations/it.json
+++ b/custom_components/homeconnect_ws/translations/it.json
@@ -1453,7 +1453,7 @@
         }
       },
       "select_hob_power_management": {
-        "name": "Gestione della potenza"
+        "name": "Potenza massima assorbita"
       },
       "select_hob_buzzer_beep_level": {
         "name": "Livello segnale acustico",

--- a/custom_components/homeconnect_ws/translations/it.json
+++ b/custom_components/homeconnect_ws/translations/it.json
@@ -1386,6 +1386,77 @@
           "medium": "Medio",
           "long": "Lungo"
         }
+      },
+      "select_hob_automatic_keylock": {
+        "name": "Blocco tasti automatico",
+        "state": {
+          "deactivated": "Manuale",
+          "activated": "Automatico",
+          "keylockfunctiondeactivated": "Disattivato"
+        }
+      },
+      "select_hob_energy_consumption_indication": {
+        "name": "Indicazione del consumo energetico",
+        "state": {
+          "indicationoff": "Nascondi",
+          "indicationon": "Mostra"
+        }
+      },
+      "select_hob_bridge_zone_mode": {
+        "name": "VarioInduzione",
+        "state": {
+          "splitmode": "Separa",
+          "joinmode": "Collegato"
+        }
+      },
+      "select_hob_power_level": {
+        "name": "Livello di potenza"
+      },
+      "select_hob_hood_automatic_light_off": {
+        "name": "Spegnimento automatico luce cappa",
+        "state": {
+          "off": "Spento",
+          "on": "Acceso"
+        }
+      },
+      "select_hob_hood_automatic_light_on": {
+        "name": "Accensione automatica luce cappa",
+        "state": {
+          "off": "Spento",
+          "on": "Acceso"
+        }
+      },
+      "select_hob_hood_automatic_start": {
+        "name": "Avvio automatico cappa",
+        "state": {
+          "off": "Spento",
+          "automaticmode": "Automatico",
+          "manualmode": "Manuale"
+        }
+      },
+      "select_hob_hood_after_run": {
+        "name": "Funzionamento prolungato cappa",
+        "state": {
+          "off": "Spento",
+          "automaticmode": "Automatico",
+          "manualmode": "Manuale",
+		  "donothing": "Invariato"
+        }
+      },
+      "select_hob_power_management": {
+        "name": "Gestione della potenza"
+      },
+      "select_hob_buzzer_beep_level": {
+        "name": "Livello segnale acustico",
+        "state": {
+          "alloff": "Tutto spento",
+		  "acknowledgeoff": "Toni tasti spenti",
+		  "warningmaloff": "Avvisi disattivati",
+		  "allactive": "Tutto attivo"
+        }
+      },
+      "select_hob_end_timer_signal_duration": {
+        "name": "End Timer Signal duration"
       }
     },
     "button": {
@@ -1432,6 +1503,9 @@
       },
       "number_oven_display_brightness": {
         "name": "Luminosità display"
+      },
+      "number_hob_automatic_timer": {
+        "name": "Automatic Timer"
       },
       "number_start_in": {
         "name": "Avvio tra"

--- a/custom_components/homeconnect_ws/translations/it.json
+++ b/custom_components/homeconnect_ws/translations/it.json
@@ -1517,7 +1517,7 @@
         "name": "Volume"
       },
       "number_hob_automatic_timer": {
-        "name": "Automatic Timer"
+        "name": "Timer automatico"
       },
       "number_start_in": {
         "name": "Avvio tra"

--- a/custom_components/homeconnect_ws/translations/nl.json
+++ b/custom_components/homeconnect_ws/translations/nl.json
@@ -143,6 +143,15 @@
       "switch_oven_display_brand_logo": {
         "name": "Merklogo weergeven"
       },
+      "switch_hob_energy_consumption_indication": {
+        "name": "Indicatie van het energieverbruik"
+      },
+      "switch_hob_hood_automatic_light_off": {
+        "name": "Automatische uitschakeling verlichting afzuigkap"
+      },
+      "switch_hob_hood_automatic_light_on": {
+        "name": "Automatische inschakeling verlichting afzuigkap"
+      },
       "switch_refrigerator_sabbath_mode": {
         "name": "Sabbat modus"
       },
@@ -1932,13 +1941,6 @@
           "keylockfunctiondeactivated": "Gedeactiveerd"
         }
       },
-      "select_hob_energy_consumption_indication": {
-        "name": "Indicatie van het energieverbruik",
-        "state": {
-          "indicationoff": "Verbergen",
-          "indicationon": "Tonen"
-        }
-      },
       "select_hob_bridge_zone_mode": {
         "name": "Vario-inductie",
         "state": {
@@ -1948,20 +1950,6 @@
       },
       "select_hob_power_level": {
         "name": "Vermogensniveau"
-      },
-      "select_hob_hood_automatic_light_off": {
-        "name": "Automatische uitschakeling verlichting afzuigkap",
-        "state": {
-          "off": "Uit",
-          "on": "Aan"
-        }
-      },
-      "select_hob_hood_automatic_light_on": {
-        "name": "Automatische inschakeling verlichting afzuigkap",
-        "state": {
-          "off": "Uit",
-          "on": "Aan"
-        }
       },
       "select_hob_hood_automatic_start": {
         "name": "Automatische start afzuigkap",

--- a/custom_components/homeconnect_ws/translations/nl.json
+++ b/custom_components/homeconnect_ws/translations/nl.json
@@ -2038,6 +2038,8 @@
           "fanstage01": "1",
           "fanstage02": "2",
           "fanstage03": "3"
+        }
+      },
       "select_hood_boost": {
         "name": "Boost",
         "state": {

--- a/custom_components/homeconnect_ws/translations/nl.json
+++ b/custom_components/homeconnect_ws/translations/nl.json
@@ -1993,7 +1993,7 @@
         }
       },
       "select_hob_end_timer_signal_duration": {
-        "name": "End Timer Signal duration"
+        "name": "Duur eindsignaal timer"
       },
       "select_hob_delayed_shutoff_stage": {
         "name": "Vertraagde uitschakeling niveau",

--- a/custom_components/homeconnect_ws/translations/nl.json
+++ b/custom_components/homeconnect_ws/translations/nl.json
@@ -1918,14 +1918,76 @@
           "highforce": "Hoog"
         }
       },
-      "select_hood_interval_stage": {
-        "name": "Interval",
+      "select_hob_automatic_keylock": {
+        "name": "Automatische toetsenvergrendeling",
         "state": {
-          "fanoff": "Uit",
-          "fanstage01": "1",
-          "fanstage02": "2",
-          "fanstage03": "3"
+          "deactivated": "Handmatig",
+          "activated": "Automatisch",
+          "keylockfunctiondeactivated": "Gedeactiveerd"
         }
+      },
+      "select_hob_energy_consumption_indication": {
+        "name": "Indicatie van het energieverbruik",
+        "state": {
+          "indicationoff": "Verbergen",
+          "indicationon": "Tonen"
+        }
+      },
+      "select_hob_bridge_zone_mode": {
+        "name": "Vario-inductie",
+        "state": {
+          "splitmode": "Splitsen",
+          "joinmode": "Gekoppeld"
+        }
+      },
+      "select_hob_power_level": {
+        "name": "Vermogensniveau"
+      },
+      "select_hob_hood_automatic_light_off": {
+        "name": "Automatische uitschakeling verlichting afzuigkap",
+        "state": {
+          "off": "Uit",
+          "on": "Aan"
+        }
+      },
+      "select_hob_hood_automatic_light_on": {
+        "name": "Automatische inschakeling verlichting afzuigkap",
+        "state": {
+          "off": "Uit",
+          "on": "Aan"
+        }
+      },
+      "select_hob_hood_automatic_start": {
+        "name": "Automatische start afzuigkap",
+        "state": {
+          "off": "Uit",
+          "automaticmode": "Automatisch",
+          "manualmode": "Handmatig"
+        }
+      },
+      "select_hob_hood_after_run": {
+        "name": "Nalooptijd afzuigkap",
+        "state": {
+          "off": "Uit",
+          "automaticmode": "Automatisch",
+          "manualmode": "Handmatig",
+		  "donothing": "Ongewijzigd"
+        }
+      },
+      "select_hob_power_management": {
+        "name": "Vermogensbeheer"
+      },
+      "select_hob_buzzer_beep_level": {
+        "name": "Niveau van het geluidssignaal",
+        "state": {
+          "alloff": "Alles uit",
+		  "acknowledgeoff": "Toetstonen uit",
+		  "warningmaloff": "Waarschuwingen uit",
+		  "allactive": "Alles actief"
+        }
+      },
+      "select_hob_end_timer_signal_duration": {
+        "name": "End Timer Signal duration"
       },
       "select_hob_delayed_shutoff_stage": {
         "name": "Vertraagde uitschakeling niveau",
@@ -1961,6 +2023,15 @@
           "level17": "Niveau 9",
           "boostlevel1": "Boost 1",
           "boostlevel2": "Boost 2"
+        }
+      },
+      "select_hood_interval_stage": {
+        "name": "Interval",
+        "state": {
+          "fanoff": "Uit",
+          "fanstage01": "1",
+          "fanstage02": "2",
+          "fanstage03": "3"
         }
       }
     },
@@ -2011,6 +2082,9 @@
       },
       "number_oven_display_brightness": {
         "name": "Helderheid display"
+      },
+      "number_hob_automatic_timer": {
+        "name": "Timer automatico"
       },
       "number_hood_interval_off": {
         "name": "Tijdsinterval uitschakelen"

--- a/custom_components/homeconnect_ws/translations/nl.json
+++ b/custom_components/homeconnect_ws/translations/nl.json
@@ -2112,7 +2112,7 @@
         "name": "Volume"
       },
       "number_hob_automatic_timer": {
-        "name": "Timer automatico"
+        "name": "Automatische timer"
       },
       "number_hood_interval_off": {
         "name": "Tijdsinterval uitschakelen"

--- a/custom_components/homeconnect_ws/translations/nl.json
+++ b/custom_components/homeconnect_ws/translations/nl.json
@@ -1984,7 +1984,7 @@
         }
       },
       "select_hob_power_management": {
-        "name": "Vermogensbeheer"
+        "name": "Maximaal opgenomen vermogen"
       },
       "select_hob_buzzer_beep_level": {
         "name": "Niveau van het geluidssignaal",

--- a/custom_components/homeconnect_ws/translations/no.json
+++ b/custom_components/homeconnect_ws/translations/no.json
@@ -1797,7 +1797,7 @@
         }
       },
       "select_hob_power_management": {
-        "name": "Effekthåndtering"
+        "name": "Maksimalt strømforbruk"
       },
       "select_hob_buzzer_beep_level": {
         "name": "Signaltonnivå",

--- a/custom_components/homeconnect_ws/translations/no.json
+++ b/custom_components/homeconnect_ws/translations/no.json
@@ -185,6 +185,15 @@
       "switch_oven_display_brand_logo": {
         "name": "Vis merkevarelogo"
       },
+      "switch_hob_energy_consumption_indication": {
+        "name": "Indikator for energiforbruk"
+      },
+      "switch_hob_hood_automatic_light_off": {
+        "name": "Automatisk slukking av ventilatorlys"
+      },
+      "switch_hob_hood_automatic_light_on": {
+        "name": "Automatisk tenning av ventilatorlys"
+      },
       "switch_refrigerator_sabbath_mode": {
         "name": "Sabbatsmodus"
       },
@@ -1745,13 +1754,6 @@
           "keylockfunctiondeactivated": "Deaktivert"
         }
       },
-      "select_hob_energy_consumption_indication": {
-        "name": "Indikator for energiforbruk",
-        "state": {
-          "indicationoff": "Skjul",
-          "indicationon": "Vis"
-        }
-      },
       "select_hob_bridge_zone_mode": {
         "name": "Varioinduksjon",
         "state": {
@@ -1761,20 +1763,6 @@
       },
       "select_hob_power_level": {
         "name": "Effektnivå"
-      },
-      "select_hob_hood_automatic_light_off": {
-        "name": "Automatisk slukking av ventilatorlys",
-        "state": {
-          "off": "Av",
-          "on": "På"
-        }
-      },
-      "select_hob_hood_automatic_light_on": {
-        "name": "Automatisk tenning av ventilatorlys",
-        "state": {
-          "off": "Av",
-          "on": "På"
-        }
       },
       "select_hob_hood_automatic_start": {
         "name": "Automatisk start av ventilator",

--- a/custom_components/homeconnect_ws/translations/no.json
+++ b/custom_components/homeconnect_ws/translations/no.json
@@ -1806,7 +1806,7 @@
         }
       },
       "select_hob_end_timer_signal_duration": {
-        "name": "End Timer Signal duration"
+        "name": "Varighet for sluttsignal på timer"
       },
       "select_temperature_unit": {
         "name": "Temperatursenhet",

--- a/custom_components/homeconnect_ws/translations/no.json
+++ b/custom_components/homeconnect_ws/translations/no.json
@@ -1722,15 +1722,6 @@
           "highforce": "Høy"
         }
       },
-      "select_hood_interval_stage": {
-        "name": "Intervalltrinn",
-        "state": {
-          "fanoff": "Av",
-          "fanstage01": "1",
-          "fanstage02": "2",
-          "fanstage03": "3"
-        }
-      },
       "select_hob_delaye_shutoff_stage": {
         "name": "Forsinket avstengingstrinn",
         "state": {
@@ -1740,11 +1731,91 @@
           "fanstage03": "3"
         }
       },
+      "select_hob_automatic_keylock": {
+        "name": "Automatisk tastelås",
+        "state": {
+          "deactivated": "Manuell",
+          "activated": "Automatisk",
+          "keylockfunctiondeactivated": "Deaktivert"
+        }
+      },
+      "select_hob_energy_consumption_indication": {
+        "name": "Indikator for energiforbruk",
+        "state": {
+          "indicationoff": "Skjul",
+          "indicationon": "Vis"
+        }
+      },
+      "select_hob_bridge_zone_mode": {
+        "name": "Varioinduksjon",
+        "state": {
+          "splitmode": "Dele",
+          "joinmode": "Koblet"
+        }
+      },
+      "select_hob_power_level": {
+        "name": "Effektnivå"
+      },
+      "select_hob_hood_automatic_light_off": {
+        "name": "Automatisk slukking av ventilatorlys",
+        "state": {
+          "off": "Av",
+          "on": "På"
+        }
+      },
+      "select_hob_hood_automatic_light_on": {
+        "name": "Automatisk tenning av ventilatorlys",
+        "state": {
+          "off": "Av",
+          "on": "På"
+        }
+      },
+      "select_hob_hood_automatic_start": {
+        "name": "Automatisk start av ventilator",
+        "state": {
+          "off": "Av",
+          "automaticmode": "Automatisk",
+          "manualmode": "Manuell"
+        }
+      },
+      "select_hob_hood_after_run": {
+        "name": "Etterløp for ventilator",
+        "state": {
+          "off": "Av",
+          "automaticmode": "Automatisk",
+          "manualmode": "Manuell",
+		  "donothing": "Uendret"
+        }
+      },
+      "select_hob_power_management": {
+        "name": "Effekthåndtering"
+      },
+      "select_hob_buzzer_beep_level": {
+        "name": "Signaltonnivå",
+        "state": {
+          "alloff": "Alt av",
+		  "acknowledgeoff": "Tastelyd av",
+		  "warningmaloff": "Varsler av",
+		  "allactive": "Alle aktive"
+        }
+      },
+      "select_hob_end_timer_signal_duration": {
+        "name": "End Timer Signal duration"
+      },
       "select_temperature_unit": {
         "name": "Temperatursenhet",
         "state": {
           "celsius": "Celsius",
           "fahrenheit": "Fahrenheit"
+        }
+      },
+      "select_hood_interval_stage": {
+        "name": "Intervalltrinn",
+        "state": {
+          "fanoff": "Av",
+          "fanstage01": "1",
+          "fanstage02": "2",
+          "fanstage03": "3"
         }
       },
       "select_hood_carbon_filter_type": {
@@ -1821,6 +1892,9 @@
       },
       "number_oven_display_brightness": {
         "name": "Skjermlysstyrke"
+      },
+      "number_hob_automatic_timer": {
+        "name": "Automatisk tidsur"
       },
       "number_hood_interval_off": {
         "name": "Intervalltid av"

--- a/custom_components/homeconnect_ws/translations/ru.json
+++ b/custom_components/homeconnect_ws/translations/ru.json
@@ -1675,7 +1675,7 @@
         }
       },
       "select_hob_power_management": {
-        "name": "Управление мощностью"
+        "name": "Максимальная потребляемая мощность"
       },
       "select_hob_buzzer_beep_level": {
         "name": "Уровень звукового сигнала",

--- a/custom_components/homeconnect_ws/translations/ru.json
+++ b/custom_components/homeconnect_ws/translations/ru.json
@@ -140,6 +140,15 @@
       "switch_oven_display_brand_logo": {
         "name": "Отобразить логотип бренда"
       },
+      "switch_hob_energy_consumption_indication": {
+        "name": "Индикация энергопотребления"
+      },
+      "switch_hob_hood_automatic_light_off": {
+        "name": "Автоматическое выключение подсветки вытяжки"
+      },
+      "switch_hob_hood_automatic_light_on": {
+        "name": "Автоматическое включение подсветки вытяжки"
+      },
       "switch_refrigerator_sabbath_mode": {
         "name": "Режим Шаббат"
       },
@@ -1623,13 +1632,6 @@
           "keylockfunctiondeactivated": "Деактивировано"
         }
       },
-      "select_hob_energy_consumption_indication": {
-        "name": "Индикация энергопотребления",
-        "state": {
-          "indicationoff": "Скрыть",
-          "indicationon": "Показать"
-        }
-      },
       "select_hob_bridge_zone_mode": {
         "name": "Вариоиндукция",
         "state": {
@@ -1639,20 +1641,6 @@
       },
       "select_hob_power_level": {
         "name": "Уровень мощности"
-      },
-      "select_hob_hood_automatic_light_off": {
-        "name": "Автоматическое выключение подсветки вытяжки",
-        "state": {
-          "off": "Выкл",
-          "on": "Вкл"
-        }
-      },
-      "select_hob_hood_automatic_light_on": {
-        "name": "Автоматическое включение подсветки вытяжки",
-        "state": {
-          "off": "Выкл",
-          "on": "Вкл"
-        }
       },
       "select_hob_hood_automatic_start": {
         "name": "Автоматический запуск вытяжки",

--- a/custom_components/homeconnect_ws/translations/ru.json
+++ b/custom_components/homeconnect_ws/translations/ru.json
@@ -1600,8 +1600,8 @@
           "highforce": "Высокая"
         }
       },
-      "select_hood_interval_stage": {
-        "name": "Интервальная ступень",
+      "select_hob_delaye_shutoff_stage": {
+        "name": "Ступень отложенного выключения",
         "state": {
           "fanoff": "Выключено",
           "fanstage01": "1",
@@ -1609,8 +1609,79 @@
           "fanstage03": "3"
         }
       },
-      "select_hob_delaye_shutoff_stage": {
-        "name": "Ступень отложенного выключения",
+      "select_hob_automatic_keylock": {
+        "name": "Автоматическая блокировка кнопок",
+        "state": {
+          "deactivated": "Вручную",
+          "activated": "Автоматический",
+          "keylockfunctiondeactivated": "Деактивировано"
+        }
+      },
+      "select_hob_energy_consumption_indication": {
+        "name": "Индикация энергопотребления",
+        "state": {
+          "indicationoff": "Скрыть",
+          "indicationon": "Показать"
+        }
+      },
+      "select_hob_bridge_zone_mode": {
+        "name": "Вариоиндукция",
+        "state": {
+          "splitmode": "Разделить",
+          "joinmode": "Объединено"
+        }
+      },
+      "select_hob_power_level": {
+        "name": "Уровень мощности"
+      },
+      "select_hob_hood_automatic_light_off": {
+        "name": "Автоматическое выключение подсветки вытяжки",
+        "state": {
+          "off": "Выкл",
+          "on": "Вкл"
+        }
+      },
+      "select_hob_hood_automatic_light_on": {
+        "name": "Автоматическое включение подсветки вытяжки",
+        "state": {
+          "off": "Выкл",
+          "on": "Вкл"
+        }
+      },
+      "select_hob_hood_automatic_start": {
+        "name": "Автоматический запуск вытяжки",
+        "state": {
+          "off": "Выкл",
+          "automaticmode": "Автоматический",
+          "manualmode": "Вручную"
+        }
+      },
+      "select_hob_hood_after_run": {
+        "name": "Остаточный ход вытяжки",
+        "state": {
+          "off": "Выкл",
+          "automaticmode": "Автоматический",
+          "manualmode": "Вручную",
+		  "donothing": "Без изменений"
+        }
+      },
+      "select_hob_power_management": {
+        "name": "Управление мощностью"
+      },
+      "select_hob_buzzer_beep_level": {
+        "name": "Уровень звукового сигнала",
+        "state": {
+          "alloff": "Все выключено",
+		  "acknowledgeoff": "Звук кнопок выкл",
+		  "warningmaloff": "Предупреждения выкл",
+		  "allactive": "Все активны"
+        }
+      },
+      "select_hob_end_timer_signal_duration": {
+        "name": "End Timer Signal duration"
+      },
+      "select_hood_interval_stage": {
+        "name": "Интервальная ступень",
         "state": {
           "fanoff": "Выключено",
           "fanstage01": "1",
@@ -1666,6 +1737,9 @@
       },
       "number_oven_display_brightness": {
         "name": "Яркость дисплея"
+      },
+      "number_hob_automatic_timer": {
+        "name": "Автоматический таймер"
       },
       "number_hood_interval_off": {
         "name": "Время интервала выключения"

--- a/custom_components/homeconnect_ws/translations/ru.json
+++ b/custom_components/homeconnect_ws/translations/ru.json
@@ -1684,7 +1684,7 @@
         }
       },
       "select_hob_end_timer_signal_duration": {
-        "name": "End Timer Signal duration"
+        "name": "Продолжительность сигнала окончания таймера"
       },
       "select_hood_interval_stage": {
         "name": "Интервальная ступень",

--- a/custom_components/homeconnect_ws/translations/sv.json
+++ b/custom_components/homeconnect_ws/translations/sv.json
@@ -1807,7 +1807,7 @@
         }
       },
       "select_hob_power_management": {
-        "name": "Effekthantering"
+        "name": "Maximal effektförbrukning"
       },
       "select_hob_buzzer_beep_level": {
         "name": "Signaltonsnivå",

--- a/custom_components/homeconnect_ws/translations/sv.json
+++ b/custom_components/homeconnect_ws/translations/sv.json
@@ -1732,8 +1732,8 @@
           "highforce": "Hög"
         }
       },
-      "select_hood_interval_stage": {
-        "name": "Intervallsteg",
+      "select_hob_delaye_shutoff_stage": {
+        "name": "Fördröjd avstängning – steg",
         "state": {
           "fanoff": "Av",
           "fanstage01": "1",
@@ -1741,8 +1741,79 @@
           "fanstage03": "3"
         }
       },
-      "select_hob_delaye_shutoff_stage": {
-        "name": "Fördröjd avstängning – steg",
+      "select_hob_automatic_keylock": {
+        "name": "Automatiskt knapplås",
+        "state": {
+          "deactivated": "Manuell",
+          "activated": "Automatisk",
+          "keylockfunctiondeactivated": "Inaktiverad"
+        }
+      },
+      "select_hob_energy_consumption_indication": {
+        "name": "Energy Consumption Indication",
+        "state": {
+          "indicationoff": "Dölj",
+          "indicationon": "Visa"
+        }
+      },
+      "select_hob_bridge_zone_mode": {
+        "name": "Varioinduktion",
+        "state": {
+          "splitmode": "Dela",
+          "joinmode": "Kopplad"
+        }
+      },
+      "select_hob_power_level": {
+        "name": "Effektnivå"
+      },
+      "select_hob_hood_automatic_light_off": {
+        "name": "Automatisk avstängning av fläktbelysning",
+        "state": {
+          "off": "Av",
+          "on": "På"
+        }
+      },
+      "select_hob_hood_automatic_light_on": {
+        "name": "Automatisk start av fläktbelysning",
+        "state": {
+          "off": "Av",
+          "on": "På"
+        }
+      },
+      "select_hob_hood_automatic_start": {
+        "name": "Automatisk start av fläkt",
+        "state": {
+          "off": "Av",
+          "automaticmode": "Automatisk",
+          "manualmode": "Manuell"
+        }
+      },
+      "select_hob_hood_after_run": {
+        "name": "Eftergång för fläkt",
+        "state": {
+          "off": "Av",
+          "automaticmode": "Automatisk",
+          "manualmode": "Manuell",
+		  "donothing": "Oförändrad"
+        }
+      },
+      "select_hob_power_management": {
+        "name": "Effekthantering"
+      },
+      "select_hob_buzzer_beep_level": {
+        "name": "Signaltonsnivå",
+        "state": {
+          "alloff": "Allt av",
+		  "acknowledgeoff": "Knappljud av",
+		  "warningmaloff": "Varningar av",
+		  "allactive": "Alla aktiva"
+        }
+      },
+      "select_hob_end_timer_signal_duration": {
+        "name": "Varaktighet för signal vid avslutad timer"
+      },
+      "select_hood_interval_stage": {
+        "name": "Intervallsteg",
         "state": {
           "fanoff": "Av",
           "fanstage01": "1",
@@ -1804,6 +1875,9 @@
       },
       "number_oven_display_brightness": {
         "name": "Display – ljusstyrka"
+      },
+      "number_hob_automatic_timer": {
+        "name": "Automatisk timer"
       },
       "number_hood_interval_off": {
         "name": "Intervall – av"

--- a/custom_components/homeconnect_ws/translations/sv.json
+++ b/custom_components/homeconnect_ws/translations/sv.json
@@ -188,6 +188,15 @@
       "switch_oven_display_brand_logo": {
         "name": "Visa varumärkeslogotyp"
       },
+      "switch_hob_energy_consumption_indication": {
+        "name": "Energy Consumption Indication"
+      },
+      "switch_hob_hood_automatic_light_off": {
+        "name": "Automatisk avstängning av fläktbelysning"
+      },
+      "switch_hob_hood_automatic_light_on": {
+        "name": "Automatisk start av fläktbelysning"
+      },
       "switch_refrigerator_sabbath_mode": {
         "name": "Sabbatsläge"
       },
@@ -1755,13 +1764,6 @@
           "keylockfunctiondeactivated": "Inaktiverad"
         }
       },
-      "select_hob_energy_consumption_indication": {
-        "name": "Energy Consumption Indication",
-        "state": {
-          "indicationoff": "Dölj",
-          "indicationon": "Visa"
-        }
-      },
       "select_hob_bridge_zone_mode": {
         "name": "Varioinduktion",
         "state": {
@@ -1771,20 +1773,6 @@
       },
       "select_hob_power_level": {
         "name": "Effektnivå"
-      },
-      "select_hob_hood_automatic_light_off": {
-        "name": "Automatisk avstängning av fläktbelysning",
-        "state": {
-          "off": "Av",
-          "on": "På"
-        }
-      },
-      "select_hob_hood_automatic_light_on": {
-        "name": "Automatisk start av fläktbelysning",
-        "state": {
-          "off": "Av",
-          "on": "På"
-        }
       },
       "select_hob_hood_automatic_start": {
         "name": "Automatisk start av fläkt",

--- a/custom_components/homeconnect_ws/translations/zh-Hans.json
+++ b/custom_components/homeconnect_ws/translations/zh-Hans.json
@@ -188,6 +188,15 @@
       "switch_oven_display_brand_logo": {
         "name": "显示品牌标志"
       },
+      "switch_hob_energy_consumption_indication": {
+        "name": "能耗指示"
+      },
+      "switch_hob_hood_automatic_light_off": {
+        "name": "油烟机自动关灯"
+      },
+      "switch_hob_hood_automatic_light_on": {
+        "name": "引擎盖自动照明"
+      },
       "switch_refrigerator_sabbath_mode": {
         "name": "安息日模式"
       },
@@ -1668,13 +1677,6 @@
           "keylockfunctiondeactivated": "已停用"
         }
       },
-      "select_hob_energy_consumption_indication": {
-        "name": "能耗指示",
-        "state": {
-          "indicationoff": "隐藏",
-          "indicationon": "展示"
-        }
-      },
       "select_hob_bridge_zone_mode": {
         "name": "桥接区域模式",
         "state": {
@@ -1684,20 +1686,6 @@
       },
       "select_hob_power_level": {
         "name": "战力等级"
-      },
-      "select_hob_hood_automatic_light_off": {
-        "name": "油烟机自动关灯",
-        "state": {
-          "off": "关闭",
-          "on": "在"
-        }
-      },
-      "select_hob_hood_automatic_light_on": {
-        "name": "引擎盖自动照明",
-        "state": {
-          "off": "关闭",
-          "on": "在"
-        }
       },
       "select_hob_hood_automatic_start": {
         "name": "油烟机自动启动",

--- a/custom_components/homeconnect_ws/translations/zh-Hans.json
+++ b/custom_components/homeconnect_ws/translations/zh-Hans.json
@@ -1711,7 +1711,7 @@
         }
       },
       "select_hob_hood_after_run": {
-        "name": "Hood After Run",
+        "name": "烟机延时关机",
         "state": {
           "off": "关闭",
           "automaticmode": "自动的",
@@ -1720,7 +1720,7 @@
         }
       },
       "select_hob_power_management": {
-        "name": "Power Management"
+        "name": "最大功耗"
       },
       "select_hob_buzzer_beep_level": {
         "name": "蜂鸣器提示音量级",

--- a/custom_components/homeconnect_ws/translations/zh-Hans.json
+++ b/custom_components/homeconnect_ws/translations/zh-Hans.json
@@ -1645,15 +1645,6 @@
           "high": "高"
         }
       },
-      "select_hood_interval_stage": {
-        "name": "间歇档位",
-        "state": {
-          "fanoff": "关闭",
-          "fanstage01": "1档",
-          "fanstage02": "2档",
-          "fanstage03": "3档"
-        }
-      },
       "select_hob_delaye_shutoff_stage": {
         "name": "延时关机档位",
         "state": {
@@ -1663,11 +1654,91 @@
           "fanstage03": "3档"
         }
       },
+      "select_hob_automatic_keylock": {
+        "name": "自动按键锁定",
+        "state": {
+          "deactivated": "手动的",
+          "activated": "自动的",
+          "keylockfunctiondeactivated": "已停用"
+        }
+      },
+      "select_hob_energy_consumption_indication": {
+        "name": "能耗指示",
+        "state": {
+          "indicationoff": "隐藏",
+          "indicationon": "展示"
+        }
+      },
+      "select_hob_bridge_zone_mode": {
+        "name": "桥接区域模式",
+        "state": {
+          "splitmode": "分裂",
+          "joinmode": "已加入"
+        }
+      },
+      "select_hob_power_level": {
+        "name": "战力等级"
+      },
+      "select_hob_hood_automatic_light_off": {
+        "name": "油烟机自动关灯",
+        "state": {
+          "off": "关闭",
+          "on": "在"
+        }
+      },
+      "select_hob_hood_automatic_light_on": {
+        "name": "引擎盖自动照明",
+        "state": {
+          "off": "关闭",
+          "on": "在"
+        }
+      },
+      "select_hob_hood_automatic_start": {
+        "name": "油烟机自动启动",
+        "state": {
+          "off": "关闭",
+          "automaticmode": "自动的",
+          "manualmode": "手动的"
+        }
+      },
+      "select_hob_hood_after_run": {
+        "name": "Hood After Run",
+        "state": {
+          "off": "关闭",
+          "automaticmode": "自动的",
+          "manualmode": "手动的",
+		  "donothing": "未变"
+        }
+      },
+      "select_hob_power_management": {
+        "name": "Power Management"
+      },
+      "select_hob_buzzer_beep_level": {
+        "name": "蜂鸣器提示音量级",
+        "state": {
+          "alloff": "全部关闭",
+		  "acknowledgeoff": "按键音已关闭",
+		  "warningmaloff": "关闭警告",
+		  "allactive": "全部启用"
+        }
+      },
+      "select_hob_end_timer_signal_duration": {
+        "name": "结束计时器信号持续时间"
+      },
       "select_temperature_unit": {
         "name": "温度单位",
         "state": {
           "celsius": "摄氏度",
           "fahrenheit": "华氏度"
+        }
+      },
+      "select_hood_interval_stage": {
+        "name": "间歇档位",
+        "state": {
+          "fanoff": "关闭",
+          "fanstage01": "1档",
+          "fanstage02": "2档",
+          "fanstage03": "3档"
         }
       },
       "select_hood_carbon_filter_type": {
@@ -1746,6 +1817,9 @@
       },
       "number_oven_display_brightness": {
         "name": "显示屏亮度"
+      },
+      "number_hob_automatic_timer": {
+        "name": "自动计时器"
       },
       "number_hood_interval_off": {
         "name": "间歇关闭时间"


### PR DESCRIPTION
Adds several settings to hob: "Automatic timer", "Automatic keylock", "BridgeZoneMode", "EnergyConsumptionIndication", "HoodAutomaticLightOff", "HoodAutomaticLightOn", "HoodAutomaticStart", "HoodAfterRun", "PowerManagement", "BuzzerBeepLevel" and "EndTimerSignalduration".
Translations (except english + german) were done by google.

Entity details:
- Automatic timer
  - Time (minutes) after which a zone turns off automatically
- Automatic keylock
  - Defines if keylock (childlock) is turned on automatically, manually or turned off completely
- BridgeZoneMode
  - When turning on hob this indicates if some zone (pre defined) are joined or split
- EnergyConsumptionIndication
  - Indicates if energy consumption (kWh) shall be displayed after hob is turned off
- PowerManagement
  - Maximum power drain (off or 1000W up to 9000W; 500W steps)
- BuzzerBeepLevel
  - Which signal types shall be played
    - never tried this myself
- EndTimerSignalduration
  - Signal duration after timer runs out
    - never tried this myself
- Those are only available if paired with a hood:
  - HoodAutomaticLightOff
    - When hob is turned off then also turn off hood light
  - HoodAutomaticLightOn
    - When hob is turned on then also turn on hood light
  - HoodAutomaticStart
    - When hob is turned on then also turn on hood fan
  - HoodAfterRun
    - When hob is turned off then also keep hood fan running (or not)