### PR TITLE
Add switch for Dishcare.Dishwasher.Option.EcoDry (EfficientDry)

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/dishcare.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/dishcare.py
@@ -322,6 +322,12 @@ DISHCARE_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             entity_category=EntityCategory.CONFIG,
             entity_registry_enabled_default=False,
         ),
+        # Also referred to as "EfficientDry"
+        HCSwitchEntityDescription(
+            key="switch_eco_dry_option",
+            entity="Dishcare.Dishwasher.Option.EcoDry",
+            device_class=SwitchDeviceClass.SWITCH,
+        ),
         HCSwitchEntityDescription(
             key="switch_extra_dry",
             entity="Dishcare.Dishwasher.Setting.ExtraDry",

--- a/custom_components/homeconnect_ws/icons.json
+++ b/custom_components/homeconnect_ws/icons.json
@@ -10,6 +10,9 @@
             "switch_extra_dry_option": {
                 "default": "mdi:heat-wave"
             },
+            "switch_eco_dry_option": {
+                "default": "mdi:heat-wave"
+            },
             "switch_intensiv_zone": {
                 "default": "mdi:pot-steam"
             },

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -113,6 +113,9 @@
       "switch_zeolite_dry": {
         "name": "CrystalDry"
       },
+      "switch_eco_dry_option": {
+        "name": "EfficientDry"
+      },
       "switch_extra_dry": {
         "name": "Extra Dry"
       },


### PR DESCRIPTION
Bosch/Siemens market this option as "EfficientDry" in newer UI/docs, but the Home Connect API still reports it as
Dishcare.Dishwasher.Option.EcoDry. The Setting and Status variants (ExtraDry, EcoDryActive) were already covered, but the per-program Option itself was missing.

Verified end-to-end against a real Bosch SMV4EVX11E dishwasher: toggling the new switch reached the appliance and the physical control panel LED changed state accordingly.