### PR TITLE
Guide users to physically confirm remote start on the appliance

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/__init__.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/__init__.py
@@ -58,6 +58,7 @@ def get_available_entities(appliance: HomeAppliance) -> EntityDescriptions:
         "event_sensor": [],
         "number": [],
         "program": [],
+        "remote_control_level": [],
         "select": [],
         "sensor": [],
         "start_button": [],

--- a/custom_components/homeconnect_ws/entity_descriptions/common.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/common.py
@@ -281,7 +281,6 @@ COMMON_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
         HCBinarySensorEntityDescription(
             key="binary_remote_start_allowed",
             entity="BSH.Common.Status.RemoteControlStartAllowed",
-            entity_registry_enabled_default=False,
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
         HCBinarySensorEntityDescription(
@@ -330,15 +329,15 @@ COMMON_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             entity_registry_enabled_default=False,
         ),
     ],
-    "select": [
+    "remote_control_level": [
         HCSelectEntityDescription(
             key="select_remote_control_level",
             entity="BSH.Common.Setting.RemoteControlLevel",
             entity_category=EntityCategory.CONFIG,
-            entity_registry_enabled_default=False,
             has_state_translation=True,
         ),
-        # cleanup: duplicate select_remote_control_level entry removed
+    ],
+    "select": [
         HCSelectEntityDescription(
             key="select_time_format",
             entity="BSH.Common.Setting.TimeFormat",

--- a/custom_components/homeconnect_ws/entity_descriptions/descriptions_definitions.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/descriptions_definitions.py
@@ -132,6 +132,7 @@ class EntityDescriptions(TypedDict):
     event_sensor: list[HCSensorEntityDescription]
     number: list[HCNumberEntityDescription]
     program: list[HCSelectEntityDescription]
+    remote_control_level: list[HCSelectEntityDescription]
     select: list[HCSelectEntityDescription]
     sensor: list[HCSensorEntityDescription]
     start_button: list[HCButtonEntityDescription]
@@ -150,6 +151,7 @@ _EntityDescriptionsDefinitionsType = dict[
         "event_sensor",
         "number",
         "program",
+        "remote_control_level",
         "select",
         "sensor",
         "start_button",
@@ -174,6 +176,7 @@ _EntityDescriptionsType = dict[
         "event_sensor",
         "number",
         "program",
+        "remote_control_level",
         "select",
         "sensor",
         "start_button",

--- a/custom_components/homeconnect_ws/select.py
+++ b/custom_components/homeconnect_ws/select.py
@@ -27,7 +27,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up select platform."""
     entities = create_entities(
-        {"select": HCSelect, "program": HCProgram},
+        {"select": HCSelect, "program": HCProgram, "remote_control_level": HCRemoteControlLevel},
         config_entry.runtime_data,
     )
     async_add_entites(entities)
@@ -127,3 +127,37 @@ class HCProgram(HCSelect):
             await selected_program.select()
         elif selected_program.execution == Execution.START_ONLY:
             await selected_program.start()
+
+
+class HCRemoteControlLevel(HCSelect):
+    """Remote Control Level select entity.
+
+    Choosing "manualremotestart" or "permanentremotestart" here only tells the
+    appliance you *want* remote start enabled. Home Connect appliances still
+    require a one-time physical confirmation directly on the appliance before
+    BSH.Common.Status.RemoteControlStartAllowed actually becomes true - no
+    client, local or cloud, can set that flag remotely. This mirrors the
+    prompt the official Home Connect app shows right after this same change.
+    """
+
+    @error_decorator
+    async def async_select_option(self, option: str) -> None:
+        await super().async_select_option(option)
+        if option == "monitoring":
+            return
+        device_name = self._runtime_data.device_info.get("name", "your appliance")
+        await self.hass.services.async_call(
+            "persistent_notification",
+            "create",
+            {
+                "title": "Home Connect Local: confirm remote start",
+                "message": (
+                    f"To finish enabling remote start on {device_name}, go to the "
+                    "appliance itself and confirm it there (e.g. press Start once "
+                    "with a program selected). This one-time physical step is "
+                    "required by the appliance's own security model - no app, "
+                    "local or cloud, can do it remotely."
+                ),
+                "notification_id": f"homeconnect_ws_confirm_remote_start_{self.entity_id}",
+            },
+        )

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -84,6 +84,26 @@ def test_get_available_entities(
     ]
 
 
+async def test_get_available_entities_real_descriptions(
+    mock_homeconnect_appliance: MockApplianceType,
+) -> None:
+    """Regression test for get_available_entities against the real descriptions.
+
+    get_available_entities() pre-initializes a dict with one key per entity
+    category; adding a new category to the entity descriptions (e.g. a new
+    "select"-like grouping) without also adding it there raises a KeyError
+    the moment a matching entity is found on a real appliance. The mocked
+    test above never exercises this because it swaps in a synthetic,
+    already-consistent description set.
+    """
+    appliance = await mock_homeconnect_appliance()
+    entities = entity_descriptions.get_available_entities(appliance)
+    assert any(
+        description.key == "select_remote_control_level"
+        for description in entities["remote_control_level"]
+    )
+
+
 POWER_SWITCH = {
     "setting": [
         {


### PR DESCRIPTION
The Start button silently stays unavailable whenever BSH.Common.Status.RemoteControlStartAllowed is false - and per the Home Connect API, that flag can only ever be set by a human physically at the appliance (Setting.RemoteControlLevel just configures the desired mode; it never flips the flag itself). No client, local or cloud, can do this remotely. Nothing in this integration explained that, so an unavailable Start button looked like a bug.

- Add HCRemoteControlLevel, a select subclass for BSH.Common.Setting.RemoteControlLevel that raises a persistent notification after a write (unless switching to Monitoring), mirroring the confirmation prompt the official Home Connect app already shows for this same setting.
- Enable select_remote_control_level and binary_remote_start_allowed by default so users can see why Start is unavailable without digging through diagnostics.
- Add a regression test: get_available_entities() pre-initializes a fixed dict of category keys, so adding a new category anywhere without also adding it there raises a KeyError the moment a matching entity shows up on a real appliance - caught live during manual testing against a real Bosch SMV4EVX11E before this patch.

Root-caused and verified end-to-end against that real dishwasher: RemoteControlStartAllowed and the Start button's availability tracked a physical confirmation on the appliance exactly as expected, and the new notification was confirmed to fire correctly.