### PR TITLE
Guide remote start confirmation beta

### DIFF
--- a/custom_components/homeconnect_ws/button.py
+++ b/custom_components/homeconnect_ws/button.py
@@ -6,9 +6,11 @@ from typing import TYPE_CHECKING
 
 from home_disconnect.entities import Execution
 from homeassistant.components.button import ButtonEntity
+from homeassistant.exceptions import HomeAssistantError
 
+from .const import DOMAIN
 from .entity import HCEntity
-from .helpers import create_entities, error_decorator
+from .helpers import create_entities, entity_is_available, error_decorator
 
 if TYPE_CHECKING:
     from home_disconnect.entities import ActiveProgram, Command
@@ -51,19 +53,38 @@ class HCStartButton(HCEntity, ButtonEntity):
 
     @property
     def available(self) -> bool:
-        available = super().available
-        available &= self._runtime_data.appliance.selected_program is not None
-        if self._runtime_data.appliance.selected_program is not None:
-            # SELECT_ONLY needs this button too - see generate_start_button.
-            available &= self._runtime_data.appliance.selected_program.execution in (
-                Execution.SELECT_AND_START,
-                Execution.SELECT_ONLY,
-            )
-        return available
+        # Deliberately skips entity_is_available()'s access check (unlike
+        # HCEntity.available): keep this button visible and pressable even
+        # when the appliance is currently refusing remote start
+        # (BSH.Common.Status.RemoteControlStartAllowed is false) - that's a
+        # normal, common appliance state, not an integration bug. async_press
+        # below checks access itself and raises a clear, actionable error
+        # instead of a silently-greyed-out button, mirroring how the official
+        # Home Connect cloud integration keeps its active-program select
+        # always available regardless of remote-control state.
+        if not self._runtime_data.appliance.session.connected:
+            return False
+        if not getattr(self._entity, "available", True):
+            return False
+        selected_program = self._runtime_data.appliance.selected_program
+        if selected_program is None:
+            return False
+        # SELECT_ONLY needs this button too - see generate_start_button.
+        return selected_program.execution in (
+            Execution.SELECT_AND_START,
+            Execution.SELECT_ONLY,
+        )
 
     @error_decorator
     async def async_press(self) -> None:
         selected_program = self._runtime_data.appliance.selected_program
         if selected_program is None:
             return
+        if not entity_is_available(self._entity, self.entity_description.available_access):
+            device_name = self._runtime_data.device_info.get("name", "your appliance")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="remote_start_not_allowed",
+                translation_placeholders={"device_name": device_name},
+            )
         await selected_program.start()

--- a/custom_components/homeconnect_ws/button.py
+++ b/custom_components/homeconnect_ws/button.py
@@ -91,7 +91,7 @@ class HCStartButton(HCEntity, ButtonEntity):
             "BSH.Common.Status.RemoteControlStartAllowed"
         )
         if remote_start_allowed is not None and remote_start_allowed.value is False:
-            device_name = self._runtime_data.device_info.get("name", "your appliance")
+            device_name = self._runtime_data.device_info.get("name") or "your appliance"
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="remote_start_not_allowed",

--- a/custom_components/homeconnect_ws/button.py
+++ b/custom_components/homeconnect_ws/button.py
@@ -10,7 +10,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
 from .entity import HCEntity
-from .helpers import create_entities, entity_is_available, error_decorator
+from .helpers import create_entities, error_decorator
 
 if TYPE_CHECKING:
     from home_disconnect.entities import ActiveProgram, Command
@@ -80,7 +80,17 @@ class HCStartButton(HCEntity, ButtonEntity):
         selected_program = self._runtime_data.appliance.selected_program
         if selected_program is None:
             return
-        if not entity_is_available(self._entity, self.entity_description.available_access):
+        # Check BSH.Common.Status.RemoteControlStartAllowed directly rather than
+        # ActiveProgram's own access field: ActiveProgram.access is "read" (not
+        # writable) whenever the appliance can't currently accept a start for
+        # *any* reason - remote start not confirmed, but equally an open door,
+        # no program selected on the appliance side, etc. Confusing those would
+        # tell a user to go press the physical confirmation button for a
+        # problem physically confirming can't fix (e.g. an open door).
+        remote_start_allowed = self._runtime_data.appliance.entities.get(
+            "BSH.Common.Status.RemoteControlStartAllowed"
+        )
+        if remote_start_allowed is not None and remote_start_allowed.value is False:
             device_name = self._runtime_data.device_info.get("name", "your appliance")
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/custom_components/homeconnect_ws/entity_descriptions/common.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/common.py
@@ -323,7 +323,6 @@ COMMON_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
         HCBinarySensorEntityDescription(
             key="binary_remote_start_allowed",
             entity="BSH.Common.Status.RemoteControlStartAllowed",
-            entity_registry_enabled_default=False,
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
         HCBinarySensorEntityDescription(
@@ -377,7 +376,6 @@ COMMON_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             key="select_remote_control_level",
             entity="BSH.Common.Setting.RemoteControlLevel",
             entity_category=EntityCategory.CONFIG,
-            entity_registry_enabled_default=False,
             has_state_translation=True,
         ),
         # cleanup: duplicate select_remote_control_level entry removed

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -3896,7 +3896,7 @@
       "message": "Entity is not Accessible"
     },
     "remote_start_not_allowed": {
-      "message": "Please enable remote start on {device_name}, by physically going there and pressing the remote start button."
+      "message": "Please enable remote start on {device_name} by physically going there and pressing the remote start button."
     },
     "code_respons": {
       "message": "Error response from Appliance: {message}"

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -3895,6 +3895,9 @@
     "access_error": {
       "message": "Entity is not Accessible"
     },
+    "remote_start_not_allowed": {
+      "message": "Please enable remote start on {device_name}, by physically going there and pressing the remote start button."
+    },
     "code_respons": {
       "message": "Error response from Appliance: {message}"
     },

--- a/tests/const.py
+++ b/tests/const.py
@@ -252,6 +252,12 @@ DEVICE_DESCRIPTION = DeviceDescription(
             available=True,
             access=Access.READ,
         ),
+        EntityDescription(
+            uid=106,
+            name="BSH.Common.Status.RemoteControlStartAllowed",
+            available=True,
+            access=Access.READ,
+        ),
     ],
     setting=[
         EntityDescription(

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -126,7 +126,12 @@ async def test_start_stays_available_when_remote_start_not_allowed(
     entity_id = "button.fake_brand_homeappliance_activeprogram"
     assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
     await mock_appliance.entities["Test.SelectedProgram"].update({"value": 500})
-    await mock_appliance.entities["Test.ActiveProgram"].update({"access": "read"})
+    await mock_appliance.entities["BSH.Common.Status.RemoteControlStartAllowed"].update(
+        {"value": False}
+    )
+    # The button only registers a callback on its own entity (ActiveProgram), not
+    # on SelectedProgram - nudge it so HA's cached state actually recomputes.
+    await mock_appliance.entities["Test.ActiveProgram"].update({"access": "readwrite"})
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -143,7 +148,9 @@ async def test_start_raises_when_remote_start_not_allowed(
     entity_id = "button.fake_brand_homeappliance_activeprogram"
     assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
     await mock_appliance.entities["Test.SelectedProgram"].update({"value": 500})
-    await mock_appliance.entities["Test.ActiveProgram"].update({"access": "read"})
+    await mock_appliance.entities["BSH.Common.Status.RemoteControlStartAllowed"].update(
+        {"value": False}
+    )
     await hass.async_block_till_done()
 
     with pytest.raises(HomeAssistantError) as exc_info:
@@ -156,6 +163,41 @@ async def test_start_raises_when_remote_start_not_allowed(
 
     assert exc_info.value.translation_key == "remote_start_not_allowed"
     mock_appliance.session.send_sync.assert_not_awaited()
+
+
+async def test_start_proceeds_when_blocked_for_a_different_reason(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,  # noqa: ARG001
+) -> None:
+    """
+    Pressing start while blocked for a non-remote-start reason must not misattribute it.
+
+    ActiveProgram.access reflects whether the appliance can currently accept a
+    start for *any* reason, not just remote-start confirmation - checking it
+    directly (instead of BSH.Common.Status.RemoteControlStartAllowed) would
+    wrongly tell a user to go press a physical button that can't fix an open
+    door. Confirmed live: RemoteControlStartAllowed was already "on" but
+    ActiveProgram.access was still "read" because the door was open, and the
+    button incorrectly showed the remote-start message anyway before this fix.
+    """
+    entity_id = "button.fake_brand_homeappliance_activeprogram"
+    assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
+    await mock_appliance.entities["Test.SelectedProgram"].update({"value": 500})
+    await mock_appliance.entities["BSH.Common.Status.RemoteControlStartAllowed"].update(
+        {"value": True}
+    )
+    await mock_appliance.entities["Test.ActiveProgram"].update({"access": "read"})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        domain=BUTTON_DOMAIN,
+        service=SERVICE_PRESS,
+        service_data={ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    mock_appliance.session.send_sync.assert_awaited_once()
 
 
 async def test_abort(

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 from home_disconnect.message import Action, Message
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
 from homeassistant.components.button import SERVICE_PRESS
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
+from homeassistant.exceptions import HomeAssistantError
 
 from . import setup_config_entry
 from .const import MOCK_CONFIG_DATA
@@ -104,6 +106,56 @@ async def test_start_available_for_select_only_program(
             },
         )
     )
+
+
+async def test_start_stays_available_when_remote_start_not_allowed(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,  # noqa: ARG001
+) -> None:
+    """
+    The start button must stay visible/pressable even when remote start is currently refused.
+
+    BSH.Common.Status.RemoteControlStartAllowed can only ever be flipped by a
+    human physically at the appliance - no client, local or cloud, can set it
+    remotely. Gating the button's availability on it made an expected, common
+    appliance state look like an integration bug instead of a silently
+    greyed-out button. async_press() is responsible for surfacing that state
+    instead (see the test below).
+    """
+    entity_id = "button.fake_brand_homeappliance_activeprogram"
+    assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
+    await mock_appliance.entities["Test.SelectedProgram"].update({"value": 500})
+    await mock_appliance.entities["Test.ActiveProgram"].update({"access": "read"})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state != "unavailable"
+
+
+async def test_start_raises_when_remote_start_not_allowed(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,  # noqa: ARG001
+) -> None:
+    """Pressing start while remote start isn't allowed must error, not silently no-op."""
+    entity_id = "button.fake_brand_homeappliance_activeprogram"
+    assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
+    await mock_appliance.entities["Test.SelectedProgram"].update({"value": 500})
+    await mock_appliance.entities["Test.ActiveProgram"].update({"access": "read"})
+    await hass.async_block_till_done()
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            domain=BUTTON_DOMAIN,
+            service=SERVICE_PRESS,
+            service_data={ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "remote_start_not_allowed"
+    mock_appliance.session.send_sync.assert_not_awaited()
 
 
 async def test_abort(


### PR DESCRIPTION
Redo of #32 (closed) against beta, addressing the review feedback there:

- The Start button no longer greys out when BSH.Common.Status.RemoteControlStartAllowed is false — it stays available, and pressing it while blocked raises a clear error telling the user to go confirm physically at the appliance, instead of a persistent_notification (not allowed for core integrations, per your comment).
- Dropped HCRemoteControlLevel and the separate remote_control_level entity category — not needed under this design, per your question on the diff. select_remote_control_level is back to a plain select, enabled by default so users can see the current mode.
- The error check reads RemoteControlStartAllowed directly rather than ActiveProgram's own access field, so it doesn't misattribute other blockers (e.g. an open door) to "go confirm remote start."

Verified end-to-end against a real Bosch SMV4EVX11E: button stays available through a real remote-start-blocked state, shows the correct error, and starts normally once confirmed.