### PR TITLE
Add Polish translation

### DIFF
--- a/custom_components/homeconnect_ws/translations/pl.json
+++ b/custom_components/homeconnect_ws/translations/pl.json
@@ -1,0 +1,3905 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Dodaj nowe urządzenia Home Connect",
+        "menu_options": {
+          "legacy_oauth_region": "Zaloguj się przez Home Connect",
+          "upload": "Prześlij plik profilu"
+        }
+      },
+      "legacy_oauth_region": {
+        "title": "Region konta Home Connect",
+        "description": "Wybierz region, w którym zarejestrowane jest Twoje konto Home Connect.",
+        "data": {
+          "region": "Region"
+        }
+      },
+      "legacy_oauth_paste": {
+        "title": "Logowanie do Home Connect",
+        "description": "Otwórz ten adres URL w przeglądarce i zaloguj się: {authorize_url}\n\nStrona nie załaduje się poprawnie (to oczekiwane zachowanie) - skopiuj pełny adres URL z paska adresu przeglądarki i wklej go poniżej.",
+        "data": {
+          "legacy_redirect_url": "Adres URL przekierowania"
+        }
+      },
+      "upload": {
+        "title": "Dodaj nowe urządzenia Home Connect",
+        "description": "Prześlij plik profilu",
+        "data": {
+          "file": "Plik profilu"
+        }
+      },
+      "device_select": {
+        "title": "Wybierz urządzenie",
+        "description": "Wybierz urządzenie, które chcesz skonfigurować"
+      },
+      "host": {
+        "title": "Wprowadź nazwę hosta",
+        "description": "Spróbuj ręcznie wprowadzić nazwę hosta lub adres IP urządzenia",
+        "data": {
+          "host": "Host / adres IP"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Połączenie z urządzeniem nie powiodło się",
+      "already_configured": "To urządzenie jest już skonfigurowane"
+    },
+    "abort": {
+      "auth_failed": "Uwierzytelnianie nie powiodło się",
+      "reauth_successful": "Ponowne uwierzytelnianie zakończyło się pomyślnie",
+      "invalid_profile_file": "Plik profilu jest nieprawidłowy",
+      "profile_file_parser_error": "Plik profilu jest nieprawidłowy: {error}",
+      "appliance_not_in_profile_file": "Plik profilu nie zawiera profilu dla tego urządzenia",
+      "all_setup": "Wszystkie urządzenia z tego pliku profilu są już skonfigurowane",
+      "oauth_fetch_failed": "Nie udało się pobrać profili urządzenia z Home Connect: {error}",
+      "reauth_entry_not_found": "Wpis konfiguracji poddawany ponownemu uwierzytelnieniu już nie istnieje"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Eksport profilu urządzenia",
+        "description": "Eksportuj profil tego urządzenia jako plik ZIP do pobrania.\n\n**Bezpieczny**: bez klucza szyfrowania ani innych wrażliwych danych. Można bezpiecznie udostępnić przy zgłaszaniu nowej funkcji. Dostarczany jako link do pobrania.\n\n**Pełny**: zawiera także lokalny klucz szyfrowania urządzenia, do przeniesienia go na inny system. Zapisywany w katalogu konfiguracyjnym (folder `homeconnect_ws_export`) zamiast linku do pobrania, aby uniknąć przesyłania klucza przez HTTP.",
+        "data": {
+          "mode": "Typ eksportu"
+        }
+      }
+    }
+  },
+  "entity": {
+    "switch": {
+      "switch_allow_backend_connection": {
+        "name": "Zezwól na połączenie z chmurą"
+      },
+      "switch_allow_consumer_insights": {
+        "name": "Zezwól na analizę danych konsumenckich"
+      },
+      "switch_synchronize_with_time_server": {
+        "name": "Synchronizacja czasu z serwerem"
+      },
+      "switch_oven_convection_conversion": {
+        "name": "Konwersja termoobiegu"
+      },
+      "switch_oven_display_standby_dimmed": {
+        "name": "Przyciemnianie wyświetlacza w trybie czuwania"
+      },
+      "switch_dishwasher_sanitation": {
+        "name": "Dezynfekcja"
+      },
+      "switch_dishwasher_time_light": {
+        "name": "Podświetlenie czasu"
+      },
+      "switch_power_state": {
+        "name": "Zasilanie"
+      },
+      "switch_hygiene_plus": {
+        "name": "Higiena Plus"
+      },
+      "switch_extra_dry_option": {
+        "name": "Dodatkowe suszenie"
+      },
+      "switch_intensiv_zone": {
+        "name": "Strefa intensywna"
+      },
+      "switch_vario_speed_plus": {
+        "name": "VariospeedPlus"
+      },
+      "switch_silence_on_demand": {
+        "name": "Cisza na żądanie"
+      },
+      "switch_brilliance_dry": {
+        "name": "Brilliance Dry"
+      },
+      "switch_zeolite_dry": {
+        "name": "CrystalDry"
+      },
+      "switch_extra_dry": {
+        "name": "Dodatkowe suszenie"
+      },
+      "switch_speed_on_demand": {
+        "name": "Prędkość na żądanie"
+      },
+      "switch_info_light": {
+        "name": "Lampka informacyjna"
+      },
+      "switch_multiple_beverages": {
+        "name": "Wiele napojów"
+      },
+      "switch_cup_warmer": {
+        "name": "Podgrzewacz do filiżanek"
+      },
+      "switch_half_load": {
+        "name": "Połowa załadunku"
+      },
+      "switch_child_lock": {
+        "name": "Blokada dla dzieci"
+      },
+      "switch_door_light_ring": {
+        "name": "Podświetlenie pierścienia drzwi"
+      },
+      "switch_drum_light": {
+        "name": "Oświetlenie bębna"
+      },
+      "switch_laundry_end_signal": {
+        "name": "Sygnał końca"
+      },
+      "switch_laundry_sound_mute": {
+        "name": "Wyciszenie dźwięku"
+      },
+      "switch_laundry_time_light": {
+        "name": "Podświetlenie czasu"
+      },
+      "switch_laundry_wrinkle_guard": {
+        "name": "Ochrona przed gnieceniem"
+      },
+      "switch_laundry_silent_mode": {
+        "name": "Tryb cichy"
+      },
+      "switch_laundry_low_temperature_hygiene": {
+        "name": "Higiena w niskiej temperaturze"
+      },
+      "switch_laundry_vario_perfect": {
+        "name": "VarioPerfect"
+      },
+      "switch_laundry_gentle": {
+        "name": "Delikatne"
+      },
+      "switch_laundry_hygiene": {
+        "name": "Higiena"
+      },
+      "switch_super_freezer": {
+        "name": "Tryb super zamrażarka"
+      },
+      "switch_super_refrigerator": {
+        "name": "Tryb super lodówka"
+      },
+      "switch_refrigerator_eco": {
+        "name": "Tryb Eco"
+      },
+      "switch_refrigerator_vacation": {
+        "name": "Tryb wakacyjny"
+      },
+      "switch_laundry_idos1_active": {
+        "name": "i-DOS 1 aktywny"
+      },
+      "switch_laundry_idos2_active": {
+        "name": "i-DOS 2 aktywny"
+      },
+      "switch_laundry_intensive_plus": {
+        "name": "Intensive Plus"
+      },
+      "switch_laundry_less_ironing": {
+        "name": "Mniej prasowania"
+      },
+      "switch_laundry_silent_wash": {
+        "name": "Ciche pranie"
+      },
+      "switch_laundry_speed_perfect": {
+        "name": "Speed Perfect"
+      },
+      "switch_laundry_soak": {
+        "name": "Moczenie"
+      },
+      "switch_laundry_prewash": {
+        "name": "Pranie wstępne"
+      },
+      "switch_laundry_rinse_hold": {
+        "name": "Wstrzymanie płukania"
+      },
+      "switch_laundry_rinse_plus1": {
+        "name": "Płukanie Plus 1"
+      },
+      "switch_laundry_rinse_plus3": {
+        "name": "Płukanie Plus 3"
+      },
+      "switch_laundry_water_and_rinse_plus1": {
+        "name": "Woda i płukanie Plus 1"
+      },
+      "switch_laundry_water_plus": {
+        "name": "Water Plus"
+      },
+      "switch_laundry_disinfectant": {
+        "name": "Środek dezynfekujący"
+      },
+      "switch_laundry_hygienic_steam": {
+        "name": "Para higieniczna"
+      },
+      "switch_oven_fast_pre_heat": {
+        "name": "Szybkie nagrzewanie wstępne"
+      },
+      "switch_oven_button_tones": {
+        "name": "Dźwięki przycisków"
+      },
+      "switch_oven_light_during_operation": {
+        "name": "Oświetlenie piekarnika podczas pracy"
+      },
+      "switch_oven_night_dimout": {
+        "name": "Przyciemnianie nocne"
+      },
+      "switch_oven_sabbath_mode": {
+        "name": "Tryb szabatowy"
+      },
+      "switch_oven_teloscopic_slide_out_refited": {
+        "name": "Prowadnice teleskopowe"
+      },
+      "switch_oven_display_brand_logo": {
+        "name": "Wyświetlanie logo marki"
+      },
+      "switch_hob_energy_consumption_indication": {
+        "name": "Wskaźnik zużycia energii"
+      },
+      "switch_hob_hood_automatic_light_off": {
+        "name": "Automatyczne wyłączanie światła okapu"
+      },
+      "switch_hob_hood_automatic_light_on": {
+        "name": "Automatyczne włączanie światła okapu"
+      },
+      "switch_refrigerator_sabbath_mode": {
+        "name": "Tryb szabatowy"
+      },
+      "switch_refrigerator_dispenser_enabled": {
+        "name": "Dozownik"
+      },
+      "switch_refrigerator_door_assistant_freezer": {
+        "name": "Asystent drzwi zamrażarki"
+      },
+      "switch_refrigerator_door_assistant_fridge": {
+        "name": "Asystent drzwi chłodziarki"
+      },
+      "switch_refrigeration_light_internal": {
+        "name": "Oświetlenie wewnętrzne"
+      },
+      "switch_refrigeration_light_theater_mode": {
+        "name": "Oświetlenie wewnętrzne – tryb teatralny"
+      },
+      "switch_hood_silence_mode": {
+        "name": "Tryb cichy"
+      },
+      "switch_refrigerator_fresh_mode": {
+        "name": "Tryb świeżości"
+      },
+      "switch_extra_rinse": {
+        "name": "Dodatkowe płukanie"
+      }
+    },
+    "binary_sensor": {
+      "binary_sensor_local_control_active": {
+        "name": "Aktywne sterowanie lokalne"
+      },
+      "binary_sensor_remote_control_active": {
+        "name": "Aktywne sterowanie zdalne"
+      },
+      "binary_sensor_backend_connected": {
+        "name": "Połączenie z chmurą"
+      },
+      "binary_sensor_oven_meatprobe_plugged": {
+        "name": "Podłączona sonda mięsna"
+      },
+      "connection": {
+        "name": "Połączenie"
+      },
+      "binary_sensor_door_state": {
+        "name": "Drzwi"
+      },
+      "binary_sensor_eco_dry_active": {
+        "name": "EcoDry aktywny"
+      },
+      "binary_sensor_aqua_stop": {
+        "name": "AquaStop wystąpił"
+      },
+      "binary_sensor_low_water_pressure": {
+        "name": "Niskie ciśnienie wody"
+      },
+      "binary_sensor_bean_container_empty": {
+        "name": "Pojemnik na ziarna pusty"
+      },
+      "binary_remote_start_allowed": {
+        "name": "Zdalne uruchamianie dozwolone"
+      },
+      "binary_sensor_refresher_level": {
+        "name": "Poziom napełnienia odświeżacza",
+        "state": {
+          "on": "słaby",
+          "off": "napełniony"
+        }
+      },
+      "binary_sensor_condensate_container_full": {
+        "name": "Zbiornik skroplin",
+        "state": {
+          "on": "pełny",
+          "off": "ok"
+        }
+      },
+      "binary_sensor_machinecareandfiltercleaningreminder": {
+        "name": "Pielęgnacja urządzenia i filtra"
+      },
+      "binary_sensor_lint_filter_full": {
+        "name": "Filtr kłaczków",
+        "state": {
+          "on": "pełny",
+          "off": "ok"
+        }
+      },
+      "binary_sensor_low_voltage": {
+        "name": "Niskie napięcie"
+      },
+      "binary_sensor_maintenance_reminder": {
+        "name": "Zalecany cykl pielęgnacji"
+      },
+      "binary_sensor_machinecarereminder": {
+        "name": "Pielęgnacja urządzenia",
+        "state": {
+          "on": "wymagana konserwacja",
+          "off": "ok"
+        }
+      },
+      "binary_sensor_machinecareandfilterreminder": {
+        "name": "Pielęgnacja urządzenia i czyszczenie filtra",
+        "state": {
+          "on": "wymagana konserwacja",
+          "off": "ok"
+        }
+      },
+      "binary_sensor_waterheatercalcified": {
+        "name": "Zakamieniała grzałka",
+        "state": {
+          "on": "wymagana konserwacja",
+          "off": "ok"
+        }
+      },
+      "binary_sensor_smartfiltercleaningreminder": {
+        "name": "Czyszczenie filtra Smart",
+        "state": {
+          "on": "wymagana konserwacja",
+          "off": "ok"
+        }
+      },
+      "binary_sensor_checkfiltersystem": {
+        "name": "Sprawdź układ filtrów",
+        "state": {
+          "on": "wymagana konserwacja",
+          "off": "ok"
+        }
+      },
+      "binary_sensor_drainingnotpossible": {
+        "name": "Odprowadzanie niemożliwe",
+        "state": {
+          "on": "wymagana konserwacja",
+          "off": "ok"
+        }
+      },
+      "binary_sensor_drainpumpblocked": {
+        "name": "Pompa odpływowa zablokowana",
+        "state": {
+          "on": "wymagana konserwacja",
+          "off": "ok"
+        }
+      },
+      "binary_sensor_flexspray_error_blocked": {
+        "name": "FlexSpray zablokowany",
+        "state": {
+          "on": "problem wykryty",
+          "off": "ok"
+        }
+      },
+      "binary_sensor_flexspray_error_general": {
+        "name": "Błąd FlexSpray",
+        "state": {
+          "on": "problem wykryty",
+          "off": "ok"
+        }
+      },
+      "binary_sensor_flexspray_error_spray_arm_not_mounted": {
+        "name": "Ramię spryskiwacza niezamontowane",
+        "state": {
+          "on": "problem wykryty",
+          "off": "ok"
+        }
+      },
+      "binary_sensor_program_finished": {
+        "name": "Program zakończony"
+      },
+      "binary_sensor_program_aborted": {
+        "name": "Program przerwany"
+      },
+      "binary_sensor_foam_detection": {
+        "name": "Wykrywanie piany"
+      },
+      "binary_sensor_supply_voltage_too_low": {
+        "name": "Napięcie zasilania za niskie"
+      },
+      "binary_sensor_water_level_too_high": {
+        "name": "Wysoki poziom wody"
+      },
+      "binary_sensor_door_not_lockable": {
+        "name": "Nie można zablokować drzwi"
+      },
+      "binary_sensor_door_not_unlockable": {
+        "name": "Nie można odblokować drzwi"
+      },
+      "binary_sensor_fatal_error_occurred": {
+        "name": "Błąd krytyczny"
+      },
+      "binary_sensor_drum_clean_reminder": {
+        "name": "Przypomnienie o czyszczeniu bębna"
+      },
+      "binary_sensor_idos2_fill_level_poor": {
+        "name": "Niski poziom i-DOS 2"
+      },
+      "binary_sensor_idos1_fill_level_poor": {
+        "name": "Niski poziom i-DOS 1"
+      },
+      "binary_sensor_chiller_common_door_state": {
+        "name": "Drzwi chłodziarki"
+      },
+      "binary_sensor_freezer_door_state": {
+        "name": "Drzwi zamrażarki"
+      },
+      "binary_sensor_idos_unit_defect": {
+        "name": "Usterka i-DOS"
+      },
+      "binary_sensor_pump_error": {
+        "name": "Błąd pompy"
+      },
+      "binary_sensor_spin_abort": {
+        "name": "Wirowanie przerwane"
+      },
+      "binary_sensor_fridge_door_state": {
+        "name": "Drzwi lodówki"
+      },
+      "binary_sensor_door_alarm_chiller_common": {
+        "name": "Alarm drzwi chłodziarki"
+      },
+      "binary_sensor_door_alarm_freezer": {
+        "name": "Alarm drzwi zamrażarki"
+      },
+      "binary_sensor_door_alarm_fridge": {
+        "name": "Alarm drzwi lodówki"
+      },
+      "binary_sensor_temperature_alarm_freezer": {
+        "name": "Alarm temperatury zamrażarki"
+      },
+      "binary_sensor_interior_illumination": {
+        "name": "Oświetlenie wnętrza"
+      },
+      "binary_sensor_refrigerator_defrost": {
+        "name": "Rozmrażanie"
+      },
+      "binary_sensor_water_filter_full": {
+        "name": "Filtr wody pełny"
+      },
+      "binary_sensor_freezer_appliance_error": {
+        "name": "Błąd urządzenia"
+      },
+      "binary_sensor_freezer_low_voltage": {
+        "name": "Niskie napięcie"
+      },
+      "binary_sensor_oven_alarm_clock_elapsed": {
+        "name": "Minutnik zakończony{group_name}"
+      },
+      "binary_sensor_alarm_clock_elapsed": {
+        "name": "Minutnik zakończony"
+      }
+    },
+    "sensor": {
+      "sensor_remaining_program_time": {
+        "name": "Pozostały czas programu"
+      },
+      "sensor_elapsed_program_time": {
+        "name": "Miniony czas programu"
+      },
+      "sensor_program_progress": {
+        "name": "Postęp programu"
+      },
+      "sensor_water_forecast": {
+        "name": "Prognoza zużycia wody"
+      },
+      "sensor_energy_forecast": {
+        "name": "Prognoza zużycia energii"
+      },
+      "sensor_operation_state": {
+        "name": "Stan operacyjny",
+        "state": {
+          "inactive": "bezczynny",
+          "ready": "gotowy",
+          "delayedstart": "opóźniony start",
+          "run": "uruchomiony",
+          "pause": "wstrzymany",
+          "actionrequired": "wymagane działanie",
+          "finished": "zakończony",
+          "error": "błąd",
+          "aborting": "przerywanie"
+        }
+      },
+      "sensor_program_phase": {
+        "name": "Faza programu",
+        "state": {
+          "none": "brak",
+          "prerinse": "wstępne płukanie",
+          "mainwash": "główne mycie",
+          "finalrinse": "końcowe płukanie",
+          "drying": "suszenie"
+        }
+      },
+      "sensor_machine_care_reminder": {
+        "name": "Przypomnienie o pielęgnacji urządzenia"
+      },
+      "sensor_active_program": {
+        "name": "Aktywny program",
+        "state": {
+          "dishcare_dishwasher_program_intensiv70": "Intensiv 70",
+          "dishcare_dishwasher_program_auto2": "Auto 2",
+          "dishcare_dishwasher_program_eco50": "Eco 50",
+          "dishcare_dishwasher_program_quick45": "Quick 45",
+          "dishcare_dishwasher_program_prerinse": "PreRinse",
+          "dishcare_dishwasher_program_quick65": "Quick 65",
+          "dishcare_dishwasher_program_machinecare": "MachineCare",
+          "dishcare_dishwasher_program_nightwash": "NightWash",
+          "dishcare_dishwasher_program_glas40": "Glass 40",
+          "dishcare_dishwasher_program_glassshine": "Brilliant Shine",
+          "dishcare_dishwasher_program_kurz60": "Speed 60",
+          "dishcare_dishwasher_program_learningdishwasher": "Inteligentny",
+          "favorite_001": "Ulubiony 1",
+          "favorite_002": "Ulubiony 2",
+          "favorite_003": "Ulubiony 3",
+          "favorite_004": "Ulubiony 4",
+          "favorite_005": "Ulubiony 5",
+          "favorite_006": "Ulubiony 6",
+          "favorite_007": "Ulubiony 7",
+          "favorite_008": "Ulubiony 8",
+          "favorite_009": "Ulubiony 9",
+          "favorite_010": "Ulubiony 10",
+          "cooking_hob_program_cookingsensor": "Czujnik gotowania",
+          "cooking_hob_program_dish_cookingsensor_beansinpressurecooker": "Czujnik gotowania: Fasola w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_beefinpressurecooker": "Czujnik gotowania: Wołowina w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_boiledeggs": "Czujnik gotowania: Jajka na twardo",
+          "cooking_hob_program_dish_cookingsensor_boilingbeef": "Czujnik gotowania: Gotowanie wołowiny",
+          "cooking_hob_program_dish_cookingsensor_boilingbroccoli": "Czujnik gotowania: Gotowanie brokułów",
+          "cooking_hob_program_dish_cookingsensor_boilingbrusselssprout": "Czujnik gotowania: Gotowanie brukselki",
+          "cooking_hob_program_dish_cookingsensor_boilingcauliflower": "Czujnik gotowania: Gotowanie kalafiora",
+          "cooking_hob_program_dish_cookingsensor_boilingchicken": "Czujnik gotowania: Gotowanie kurczaka",
+          "cooking_hob_program_dish_cookingsensor_boilinggreenbeans": "Czujnik gotowania: Gotowanie fasolki szparagowej",
+          "cooking_hob_program_dish_cookingsensor_boilingmeatballs": "Czujnik gotowania: Gotowanie pulpetów",
+          "cooking_hob_program_dish_cookingsensor_boilingpotatoes": "Czujnik gotowania: Gotowanie ziemniaków",
+          "cooking_hob_program_dish_cookingsensor_chickeninpressurecooker": "Czujnik gotowania: Kurczak w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_chickpeas": "Czujnik gotowania: Ciecierzyca",
+          "cooking_hob_program_dish_cookingsensor_chickpeasinpressurecooker": "Czujnik gotowania: Ciecierzyca w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_chocolatepudding": "Czujnik gotowania: Budyń czekoladowy",
+          "cooking_hob_program_dish_cookingsensor_compote": "Czujnik gotowania: Kompot",
+          "cooking_hob_program_dish_cookingsensor_creamsoups": "Czujnik gotowania: Zupy kremowe",
+          "cooking_hob_program_dish_cookingsensor_deepfryingberliners": "Czujnik gotowania: Głębokie smażenie: pączki berlińskie",
+          "cooking_hob_program_dish_cookingsensor_deepfryingbreadedfish": "Czujnik gotowania: Głębokie smażenie: ryba panierowana",
+          "cooking_hob_program_dish_cookingsensor_deepfryingbreadedmushrooms": "Czujnik gotowania: Głębokie smażenie: grzyby panierowane",
+          "cooking_hob_program_dish_cookingsensor_deepfryingbreadedvegetables": "Czujnik gotowania: Głębokie smażenie: warzywa panierowane",
+          "cooking_hob_program_dish_cookingsensor_deepfryingbunuelos": "Czujnik gotowania: Głębokie smażenie: buñuelos",
+          "cooking_hob_program_dish_cookingsensor_deepfryingchickenportions": "Czujnik gotowania: Głębokie smażenie: porcje kurczaka",
+          "cooking_hob_program_dish_cookingsensor_deepfryingdonuts": "Czujnik gotowania: Głębokie smażenie: pączki",
+          "cooking_hob_program_dish_cookingsensor_deepfryingfishinbeerbatter": "Czujnik gotowania: Głębokie smażenie: ryba w cieście piwnym",
+          "cooking_hob_program_dish_cookingsensor_deepfryingfrenchfriesfrozen": "Czujnik gotowania: Głębokie smażenie: frytki (mrożone)",
+          "cooking_hob_program_dish_cookingsensor_deepfryingmeatballs": "Czujnik gotowania: Głębokie smażenie: pulpety",
+          "cooking_hob_program_dish_cookingsensor_deepfryingmushroomsinbeerbatter": "Czujnik gotowania: Głębokie smażenie: grzyby w cieście piwnym",
+          "cooking_hob_program_dish_cookingsensor_deepfryingvegetablesinbeerbatter": "Czujnik gotowania: Głębokie smażenie: warzywa w cieście piwnym",
+          "cooking_hob_program_dish_cookingsensor_greenbeansfrozen": "Czujnik gotowania: Fasolka szparagowa (mrożona)",
+          "cooking_hob_program_dish_cookingsensor_heatingupgoulashsoup": "Czujnik gotowania: Podgrzewanie zupy gulaszowej",
+          "cooking_hob_program_dish_cookingsensor_heatinguphotspicedwine": "Czujnik gotowania: Podgrzewanie grzańca",
+          "cooking_hob_program_dish_cookingsensor_heatingupmilk": "Czujnik gotowania: Podgrzewanie mleka",
+          "cooking_hob_program_dish_cookingsensor_homemadestock": "Czujnik gotowania: Domowy wywar",
+          "cooking_hob_program_dish_cookingsensor_homemadestockinpressurecooker": "Czujnik gotowania: Domowy wywar w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_instantsoups": "Czujnik gotowania: Zupy błyskawiczne",
+          "cooking_hob_program_dish_cookingsensor_lentils": "Czujnik gotowania: Soczewica",
+          "cooking_hob_program_dish_cookingsensor_lentilsinpressurecooker": "Czujnik gotowania: Soczewica w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_pasta": "Czujnik gotowania: Makaron",
+          "cooking_hob_program_dish_cookingsensor_peas": "Czujnik gotowania: Groszek",
+          "cooking_hob_program_dish_cookingsensor_polenta": "Czujnik gotowania: Polenta",
+          "cooking_hob_program_dish_cookingsensor_porridgesoats": "Czujnik gotowania: Owsianka",
+          "cooking_hob_program_dish_cookingsensor_potatodumplings": "Czujnik gotowania: Kluski ziemniaczane",
+          "cooking_hob_program_dish_cookingsensor_potatoesinpressurecooker": "Czujnik gotowania: Ziemniaki w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_rice": "Czujnik gotowania: Ryż",
+          "cooking_hob_program_dish_cookingsensor_riceinpressurecooker": "Czujnik gotowania: Ryż w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_ricepudding": "Czujnik gotowania: Ryż na mleku",
+          "cooking_hob_program_dish_cookingsensor_sauteedfish": "Czujnik gotowania: Ryba saute",
+          "cooking_hob_program_dish_cookingsensor_semolinapuree": "Czujnik gotowania: Puree mannowe",
+          "cooking_hob_program_dish_cookingsensor_simmeringsausages": "Czujnik gotowania: Duszenie kiełbasek",
+          "cooking_hob_program_dish_cookingsensor_stuffedpasta": "Czujnik gotowania: Makaron nadziewany",
+          "cooking_hob_program_dish_cookingsensor_vegetablesinpressurecooker": "Czujnik gotowania: Warzywa w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_vegetableswithcreamfrozen": "Czujnik gotowania: Warzywa ze śmietaną (mrożone)",
+          "cooking_hob_program_dish_fryingsensor_aubergines": "Czujnik smażenia: Bakłażany",
+          "cooking_hob_program_dish_fryingsensor_bacon": "Czujnik smażenia: Bekon",
+          "cooking_hob_program_dish_fryingsensor_bechamelsauce": "Czujnik smażenia: Sos beszamelowy",
+          "cooking_hob_program_dish_fryingsensor_camembertfrozen": "Czujnik smażenia: Camembert (mrożony)",
+          "cooking_hob_program_dish_fryingsensor_cheesesauce": "Czujnik smażenia: Sos serowy",
+          "cooking_hob_program_dish_fryingsensor_chickennuggetsfrozen": "Czujnik smażenia: Nuggets z kurczaka (mrożone)",
+          "cooking_hob_program_dish_fryingsensor_chop": "Czujnik smażenia: Kotlet",
+          "cooking_hob_program_dish_fryingsensor_cordonbleu": "Czujnik smażenia: Cordon Bleu",
+          "cooking_hob_program_dish_fryingsensor_cordonbleufrozen": "Czujnik smażenia: Cordon Bleu (mrożony)",
+          "cooking_hob_program_dish_fryingsensor_courgettes": "Czujnik smażenia: Cukinia",
+          "cooking_hob_program_dish_fryingsensor_driedreadymeals": "Czujnik smażenia: Gotowe posiłki (suszone)",
+          "cooking_hob_program_dish_fryingsensor_escalope": "Czujnik smażenia: Eskalopek",
+          "cooking_hob_program_dish_fryingsensor_escalopebreaded": "Czujnik smażenia: Panierowany eskalopek",
+          "cooking_hob_program_dish_fryingsensor_escalopefrozen": "Czujnik smażenia: Eskalopki (mrożone)",
+          "cooking_hob_program_dish_fryingsensor_fillet": "Czujnik smażenia: Filet",
+          "cooking_hob_program_dish_fryingsensor_fishfilletbreaded": "Czujnik smażenia: Panierowany filet rybny",
+          "cooking_hob_program_dish_fryingsensor_fishfilletbreadedfrozen": "Czujnik smażenia: Filet rybny panierowany (mrożony)",
+          "cooking_hob_program_dish_fryingsensor_fishfilletplain": "Czujnik smażenia: Filet rybny (bez panierki)",
+          "cooking_hob_program_dish_fryingsensor_fishfilletplainfrozen": "Czujnik smażenia: Filet rybny naturalny (mrożony)",
+          "cooking_hob_program_dish_fryingsensor_fishfingersfrozen": "Czujnik smażenia: Paluszki rybne (mrożone)",
+          "cooking_hob_program_dish_fryingsensor_frenchfriesmadefromrawpotatoes": "Czujnik smażenia: Frytki ze świeżych ziemniaków",
+          "cooking_hob_program_dish_fryingsensor_frenchtoast": "Czujnik smażenia: French Toast",
+          "cooking_hob_program_dish_fryingsensor_friedeggsinbutter": "Czujnik smażenia: Jajka sadzone na maśle",
+          "cooking_hob_program_dish_fryingsensor_friedeggsinoil": "Czujnik smażenia: Jajka sadzone na oleju",
+          "cooking_hob_program_dish_fryingsensor_fryingcamembert": "Czujnik smażenia: Smażony camembert",
+          "cooking_hob_program_dish_fryingsensor_fryingcroutons": "Czujnik smażenia: Grzanki",
+          "cooking_hob_program_dish_fryingsensor_fryingfishwhole": "Czujnik smażenia: Cała ryba (smażona)",
+          "cooking_hob_program_dish_fryingsensor_fryingfrenchfriesfrozen": "Czujnik smażenia: Mrożone frytki",
+          "cooking_hob_program_dish_fryingsensor_fryinggreenasparagus": "Czujnik smażenia: Zielone szparagi",
+          "cooking_hob_program_dish_fryingsensor_fryingmeatballs": "Czujnik smażenia: Pulpety",
+          "cooking_hob_program_dish_fryingsensor_fryingpotatoesboiledintheirskin": "Czujnik smażenia: Ziemniaki gotowane w łupinach",
+          "cooking_hob_program_dish_fryingsensor_fryingpreboiledsausages": "Czujnik smażenia: Parzone kiełbaski",
+          "cooking_hob_program_dish_fryingsensor_fryingrawsausages": "Czujnik smażenia: Surowe kiełbaski",
+          "cooking_hob_program_dish_fryingsensor_fryingrissoles": "Czujnik smażenia: Kotleciki mielone",
+          "cooking_hob_program_dish_fryingsensor_garlic": "Czujnik smażenia: Czosnek",
+          "cooking_hob_program_dish_fryingsensor_glazedonions": "Czujnik smażenia: Cebula w glazurze",
+          "cooking_hob_program_dish_fryingsensor_glazedpotatoes": "Czujnik smażenia: Ziemniaki w glazurze",
+          "cooking_hob_program_dish_fryingsensor_glazedvegetables": "Czujnik smażenia: Warzywa w glazurze",
+          "cooking_hob_program_dish_fryingsensor_gyros": "Czujnik smażenia: Gyros",
+          "cooking_hob_program_dish_fryingsensor_gyrosfrozen": "Czujnik smażenia: Gyros (mrożony)",
+          "cooking_hob_program_dish_fryingsensor_hamburgers": "Czujnik smażenia: Hamburgery",
+          "cooking_hob_program_dish_fryingsensor_kebabfrozen": "Czujnik smażenia: Kebab (mrożony)",
+          "cooking_hob_program_dish_fryingsensor_meatloaf": "Czujnik smażenia: Pieczeń rzymska",
+          "cooking_hob_program_dish_fryingsensor_mincedmeat": "Czujnik smażenia: Mięso mielone",
+          "cooking_hob_program_dish_fryingsensor_mushrooms": "Czujnik smażenia: Grzyby",
+          "cooking_hob_program_dish_fryingsensor_omelettes": "Czujnik smażenia: Omlety",
+          "cooking_hob_program_dish_fryingsensor_pancake": "Czujnik smażenia: Naleśnik",
+          "cooking_hob_program_dish_fryingsensor_pancakes": "Czujnik smażenia: Naleśniki",
+          "cooking_hob_program_dish_fryingsensor_peppers": "Czujnik smażenia: Papryka",
+          "cooking_hob_program_dish_fryingsensor_potatopancakes": "Czujnik smażenia: Placki ziemniaczane",
+          "cooking_hob_program_dish_fryingsensor_poultrybreast": "Czujnik smażenia: Pierś drobiowa",
+          "cooking_hob_program_dish_fryingsensor_poultrybreastfrozen": "Czujnik smażenia: Pierś drobiowa (mrożona)",
+          "cooking_hob_program_dish_fryingsensor_prawns": "Czujnik smażenia: Krewetki",
+          "cooking_hob_program_dish_fryingsensor_reducingsauces": "Czujnik smażenia: Redukowanie sosów",
+          "cooking_hob_program_dish_fryingsensor_sauteingvegetablesinoil": "Czujnik smażenia: Podsmażane warzywa",
+          "cooking_hob_program_dish_fryingsensor_scampi": "Czujnik smażenia: Krewetki scampi",
+          "cooking_hob_program_dish_fryingsensor_scrambledeggs": "Czujnik smażenia: Jajecznica",
+          "cooking_hob_program_dish_fryingsensor_springrollsfrozen": "Czujnik smażenia: Sajgonki (mrożone)",
+          "cooking_hob_program_dish_fryingsensor_steaksmedium": "Czujnik smażenia: Steki (średnio wysmażone)",
+          "cooking_hob_program_dish_fryingsensor_steaksrare": "Czujnik smażenia: Steki (krwiste)",
+          "cooking_hob_program_dish_fryingsensor_steakswelldone": "Czujnik smażenia: Steki (dobrze wysmażone)",
+          "cooking_hob_program_dish_fryingsensor_stirfriesfrozen": "Czujnik smażenia: Stir-Fry (mrożone)",
+          "cooking_hob_program_dish_fryingsensor_stripsofmeat": "Czujnik smażenia: Paski mięsa",
+          "cooking_hob_program_dish_fryingsensor_sweetsauces": "Czujnik smażenia: Słodkie sosy",
+          "cooking_hob_program_dish_fryingsensor_swissroesti": "Czujnik smażenia: Rösti szwajcarskie",
+          "cooking_hob_program_dish_fryingsensor_toastingalmonds": "Czujnik smażenia: Prażenie migdałów",
+          "cooking_hob_program_dish_fryingsensor_toastingnuts": "Czujnik smażenia: Prażenie orzechów",
+          "cooking_hob_program_dish_fryingsensor_toastingpinenuts": "Czujnik smażenia: Prażenie orzeszków piniowych",
+          "cooking_hob_program_dish_fryingsensor_tomatosaucewithvegetables": "Czujnik smażenia: Sos pomidorowy z warzywami",
+          "cooking_hob_program_dish_fryingsensor_vienneseschnitzel": "Czujnik smażenia: Sznycel wiedeński",
+          "cooking_hob_program_fryingsensormode": "Tryb czujnika smażenia",
+          "cooking_hob_program_powerlevelmode": "Tryb poziomu mocy",
+          "cooking_hob_program_powermovemode": "Tryb PowerMove",
+          "cooking_oven_program_heatingmode_bottomheating": "Nagrzewanie dolne",
+          "cooking_oven_program_heatingmode_frozenheatupspecial": "Funkcja coolstart",
+          "cooking_oven_program_heatingmode_grillargearea": "Grillowanie, duży obszar",
+          "cooking_oven_program_heatingmode_grillsmallarea": "Grillowanie, mały obszar",
+          "cooking_oven_program_heatingmode_hotair": "Termoobieg",
+          "cooking_oven_program_heatingmode_hotaireco": "Termoobieg eco",
+          "cooking_oven_program_heatingmode_hotairgrilling": "Grillowanie z termoobiegiem",
+          "cooking_oven_program_heatingmode_keepwarm": "Podtrzymywanie ciepła",
+          "cooking_oven_program_heatingmode_pizzasetting": "Ustawienie pizza",
+          "cooking_oven_program_heatingmode_preheatovenware": "Podgrzewanie naczyń",
+          "cooking_oven_program_heatingmode_sabbathprogramme": "Program szabatu",
+          "cooking_oven_program_heatingmode_slowcook": "Wolne gotowanie",
+          "cooking_oven_program_heatingmode_topbottomheating": "Grzanie górne i dolne",
+          "cooking_oven_program_heatingmode_topbottomheatingeco": "Grzanie górne i dolne eco",
+          "cooking_oven_program_microwave_90watt": "Mikrofalówka 90 W",
+          "cooking_oven_program_microwave_180watt": "Mikrofalówka 180 W",
+          "cooking_oven_program_microwave_360watt": "Mikrofalówka 360 W",
+          "cooking_oven_program_microwave_600watt": "Mikrofalówka 600 W",
+          "cooking_oven_program_microwave_max": "Mikrofalówka – maks.",
+          "cooking_oven_program_cleaning_drying": "Czyszczenie: Suszenie",
+          "cooking_oven_program_cleaning_easyclean": "Czyszczenie: EasyClean",
+          "cooking_oven_program_cleaning_pyrolysis": "Czyszczenie: Pyroliza",
+          "cooking_oven_program_dish_automatic_conv_beefroulade": "Auto: Roladka wołowa",
+          "cooking_oven_program_dish_automatic_conv_belly": "Auto: Boczek wieprzowy",
+          "cooking_oven_program_dish_automatic_conv_bonelesslegoflambmedium": "Auto: Udziec jagnięcy bez kości (średni)",
+          "cooking_oven_program_dish_automatic_conv_bonelesslegoflambwelldone": "Auto: Udziec jagnięcy bez kości (wypieczony)",
+          "cooking_oven_program_dish_automatic_conv_bonelesslegofroevenison": "Auto: Udziec sarny bez kości",
+          "cooking_oven_program_dish_automatic_conv_bonelesslegofvenison": "Auto: Udziec jelenia bez kości",
+          "cooking_oven_program_dish_automatic_conv_bonelessporkneckjoint": "Auto: Karkówka bez kości",
+          "cooking_oven_program_dish_automatic_conv_fishwholestew": "Auto: Cała ryba (duszona)",
+          "cooking_oven_program_dish_automatic_conv_goosebreast": "Auto: Pierś gęsi",
+          "cooking_oven_program_dish_automatic_conv_gooselegs": "Auto: Udka gęsi",
+          "cooking_oven_program_dish_automatic_conv_goulash": "Auto: Gulasz",
+          "cooking_oven_program_dish_automatic_conv_jointofporkwithcracklingegshoulder": "Auto: Łopatka wieprzowa ze skórką",
+          "cooking_oven_program_dish_automatic_conv_jointofveallean": "Auto: Cielęcina (chuda)",
+          "cooking_oven_program_dish_automatic_conv_jointofvealmarbled": "Auto: Cielęcina (marmurkowa)",
+          "cooking_oven_program_dish_automatic_conv_knuckleofveal": "Auto: Gicz cielęca",
+          "cooking_oven_program_dish_automatic_conv_legoflambonthebonewelldone": "Auto: Udziec jagnięcy z kością (wypieczony)",
+          "cooking_oven_program_dish_automatic_conv_meatloafmadefromfreshmincedmeat": "Auto: Pieczeń rzymska ze świeżego mięsa mielonego",
+          "cooking_oven_program_dish_automatic_conv_microwave_bakesavouryfreshcookedingredients": "Auto (mikrofalówka): Zapiekanka wytrawna (świeże/gotowane składniki)",
+          "cooking_oven_program_dish_automatic_conv_microwave_bakesweetfresh": "Auto (mikrofalówka): Zapiekanka słodka (świeża)",
+          "cooking_oven_program_dish_automatic_conv_microwave_bonelesslegoflambmedium": "Auto (mikrofalówka): Udziec jagnięcy bez kości (średni)",
+          "cooking_oven_program_dish_automatic_conv_microwave_bonelesslegoflambwelldone": "Auto (mikrofalówka): Udziec jagnięcy bez kości (wypieczony)",
+          "cooking_oven_program_dish_automatic_conv_microwave_bonelessporkneckjoint": "Auto (mikrofalówka): Karkówka bez kości",
+          "cooking_oven_program_dish_automatic_conv_microwave_cannelloni": "Auto (mikrofalówka): Cannelloni",
+          "cooking_oven_program_dish_automatic_conv_microwave_chickengoujonsnuggets": "Auto (mikrofalówka): Goujons/Nuggets z kurczaka",
+          "cooking_oven_program_dish_automatic_conv_microwave_chickenlegswithvegetables": "Auto (mikrofalówka): Udka z kurczaka z warzywami",
+          "cooking_oven_program_dish_automatic_conv_microwave_chickenparts": "Auto (mikrofalówka): Części kurczaka",
+          "cooking_oven_program_dish_automatic_conv_microwave_chips": "Auto (mikrofalówka): Frytki",
+          "cooking_oven_program_dish_automatic_conv_microwave_croquettes": "Auto (mikrofalówka): Krokiety",
+          "cooking_oven_program_dish_automatic_conv_microwave_defrostbreadrolls": "Auto (mikrofalówka): Rozmrażanie bułek",
+          "cooking_oven_program_dish_automatic_conv_microwave_halvedchicken": "Auto (mikrofalówka): Połówka kurczaka",
+          "cooking_oven_program_dish_automatic_conv_microwave_lasagnefrozen": "Auto (mikrofalówka): Lazania (mrożona)",
+          "cooking_oven_program_dish_automatic_conv_microwave_meatloafmadefromfreshmincedmeat": "Auto (mikrofalówka): Pieczeń rzymska ze świeżego mięsa mielonego",
+          "cooking_oven_program_dish_automatic_conv_microwave_minipizzas": "Auto (mikrofalówka): Mini pizze",
+          "cooking_oven_program_dish_automatic_conv_microwave_partcookedbreadrollsorbaguettefrozen": "Auto (mikrofalówka): Podpieczone bułki/bagietki (mrożone)",
+          "cooking_oven_program_dish_automatic_conv_microwave_pizzathickcrust1slicefrozen": "Auto (mikrofalówka): Pizza gruby spód 1 kawałek (mrożona)",
+          "cooking_oven_program_dish_automatic_conv_microwave_pizzathincrust1slice": "Auto (mikrofalówka): Pizza cienki spód 1 kawałek",
+          "cooking_oven_program_dish_automatic_conv_microwave_potatogratinrawingredients4cmdeep": "Auto (mikrofalówka): Gratin ziemniaczany (surowe składniki, 4 cm)",
+          "cooking_oven_program_dish_automatic_conv_microwave_potatopocketsfilled": "Auto (mikrofalówka): Nadziewane kieszonki ziemniaczane",
+          "cooking_oven_program_dish_automatic_conv_microwave_sirloinmedium": "Auto (mikrofalówka): Rostbef (średni)",
+          "cooking_oven_program_dish_automatic_conv_microwave_squidringsbreaded": "Auto (mikrofalówka): Panierowane pierścienie kalmara",
+          "cooking_oven_program_dish_automatic_conv_microwave_turkeybreast": "Auto (mikrofalówka): Pierś indyka",
+          "cooking_oven_program_dish_automatic_conv_microwave_unstuffedchicken": "Auto (mikrofalówka): Kurczak (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_microwave_wholebakedpotatoes": "Auto (mikrofalówka): Pieczone całe ziemniaki",
+          "cooking_oven_program_dish_automatic_conv_pavlova": "Auto: Beza Pavlova",
+          "cooking_oven_program_dish_automatic_conv_porkchopfryonthebone": "Auto: Kotlet wieprzowy z kością",
+          "cooking_oven_program_dish_automatic_conv_potroastedbeef": "Auto: Wołowina duszona",
+          "cooking_oven_program_dish_automatic_conv_poulardunstuffed": "Auto: Pularada (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_roastjoint": "Auto: Pieczona pieczeń",
+          "cooking_oven_program_dish_automatic_conv_roastporkloin": "Auto: Pieczeń wieprzowa (schab)",
+          "cooking_oven_program_dish_automatic_conv_rolledporkjoint": "Auto: Zwijana pieczeń wieprzowa",
+          "cooking_oven_program_dish_automatic_conv_salmonfillet": "Auto: Filet z łososia",
+          "cooking_oven_program_dish_automatic_conv_scandinavianchristmasham": "Auto: Skandynawska szynka bożonarodzeniowa",
+          "cooking_oven_program_dish_automatic_conv_sirloinmedium": "Auto: Rostbef (średni)",
+          "cooking_oven_program_dish_automatic_conv_sirloinrare": "Auto: Rostbef (krwisty)",
+          "cooking_oven_program_dish_automatic_conv_slowroastjoint": "Auto: Powolna pieczeń",
+          "cooking_oven_program_dish_automatic_conv_stewwithmeat": "Auto: Gulasz z mięsem",
+          "cooking_oven_program_dish_automatic_conv_stewwithvegetables": "Auto: Gulasz z warzywami",
+          "cooking_oven_program_dish_automatic_conv_turkeybreast": "Auto: Pierś indyka",
+          "cooking_oven_program_dish_automatic_conv_unstuffedchicken": "Auto: Kurczak (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_unstuffedduck": "Auto: Kaczka (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_unstuffedgoose": "Auto: Gęś (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_unstuffedsmallturkey": "Auto: Mały indyk (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_vealossobuco": "Auto: Ossobuco z cielęciny",
+          "cooking_oven_program_dish_automatic_conv_wholerabbit": "Auto: Cały królik",
+          "cooking_oven_program_dish_automatic_conv_wildboarroast": "Auto: Pieczeń z dzika",
+          "cooking_oven_program_dish_automatic_microwave_basmatirice": "Auto (mikrofalówka): Ryż basmati",
+          "cooking_oven_program_dish_automatic_microwave_boiledpotatoes": "Auto (mikrofalówka): Ziemniaki gotowane",
+          "cooking_oven_program_dish_automatic_microwave_boiledpotatoeswskin": "Auto (mikrofalówka): Ziemniaki gotowane w mundurkach",
+          "cooking_oven_program_dish_automatic_microwave_brownrice": "Auto (mikrofalówka): Ryż brązowy",
+          "cooking_oven_program_dish_automatic_microwave_cakedrydefrost": "Auto (mikrofalówka): Rozmrażanie ciasta (suche)",
+          "cooking_oven_program_dish_automatic_microwave_couscous": "Auto (mikrofalówka): Kuskus",
+          "cooking_oven_program_dish_automatic_microwave_defrostcakesmoist": "Auto (mikrofalówka): Rozmrażanie ciast (wilgotnych)",
+          "cooking_oven_program_dish_automatic_microwave_defrostfishfillet": "Auto (mikrofalówka): Rozmrażanie filetu rybnego",
+          "cooking_oven_program_dish_automatic_microwave_defrostfishwhole": "Auto (mikrofalówka): Rozmrażanie ryby w całości",
+          "cooking_oven_program_dish_automatic_microwave_defrostmeat": "Auto (mikrofalówka): Rozmrażanie mięsa",
+          "cooking_oven_program_dish_automatic_microwave_defrostmultigrainbread": "Auto (mikrofalówka): Rozmrażanie chleba wieloziarnistego",
+          "cooking_oven_program_dish_automatic_microwave_defrostpoultryportions": "Auto (mikrofalówka): Rozmrażanie porcji drobiu",
+          "cooking_oven_program_dish_automatic_microwave_defrostspinach": "Auto (mikrofalówka): Rozmrażanie szpinaku",
+          "cooking_oven_program_dish_automatic_microwave_defrostwhitebread": "Auto (mikrofalówka): Rozmrażanie chleba pszennego",
+          "cooking_oven_program_dish_automatic_microwave_defrostveg": "Auto (mikrofalówka): Rozmrażanie warzyw",
+          "cooking_oven_program_dish_automatic_microwave_defrostberries": "Auto (mikrofalówka): Rozmrażanie owoców jagodowych",
+          "cooking_oven_program_dish_automatic_microwave_defrostmincedmeat": "Auto (mikrofalówka): Rozmrażanie mięsa mielonego",
+          "cooking_oven_program_dish_automatic_microwave_defrostpoultry": "Auto (mikrofalówka): Rozmrażanie drobiu",
+          "cooking_oven_program_dish_automatic_microwave_defrostsoup": "Auto (mikrofalówka): Rozmrażanie zupy",
+          "cooking_oven_program_dish_automatic_microwave_dissolvegelatine": "Auto (mikrofalówka): Rozpuszczanie żelatyny",
+          "cooking_oven_program_dish_automatic_microwave_dissolveyeast": "Auto (mikrofalówka): Rozpuszczanie drożdży",
+          "cooking_oven_program_dish_automatic_microwave_heatupbeverages": "Auto (mikrofalówka): Podgrzewanie napojów",
+          "cooking_oven_program_dish_automatic_microwave_heatupplatedmeal": "Auto (mikrofalówka): Podgrzewanie posiłku na talerzu",
+          "cooking_oven_program_dish_automatic_microwave_longgrainrice": "Auto (mikrofalówka): Ryż długoziarnisty",
+          "cooking_oven_program_dish_automatic_microwave_meltbutter": "Auto (mikrofalówka): Rozpuszczanie masła",
+          "cooking_oven_program_dish_automatic_microwave_meltchocolate": "Auto (mikrofalówka): Rozpuszczanie czekolady",
+          "cooking_oven_program_dish_automatic_microwave_meltcookingchocolate": "Auto (mikrofalówka): Rozpuszczanie czekolady kuchennej",
+          "cooking_oven_program_dish_automatic_microwave_milletorquinoa": "Auto (mikrofalówka): Kasza jaglana lub komosa ryżowa",
+          "cooking_oven_program_dish_automatic_microwave_mixedgrain": "Auto (mikrofalówka): Mieszanka zbóż",
+          "cooking_oven_program_dish_automatic_microwave_oatmealorricepudding": "Auto (mikrofalówka): Owsianka lub ryż na mleku",
+          "cooking_oven_program_dish_automatic_microwave_polenta": "Auto (mikrofalówka): Polenta",
+          "cooking_oven_program_dish_automatic_microwave_popcorn": "Auto (mikrofalówka): Popcorn",
+          "cooking_oven_program_dish_automatic_microwave_semolinapudding": "Auto (mikrofalówka): Budyń mannowy",
+          "cooking_oven_program_dish_automatic_microwave_softenbutter": "Auto (mikrofalówka): Zmiękczanie masła",
+          "cooking_oven_program_dish_automatic_microwave_softenicecream": "Auto (mikrofalówka): Zmiękczanie lodów",
+          "cooking_oven_program_dish_automatic_microwave_spinachleavescauliflowerflorets": "Auto (mikrofalówka): Liście szpinaku/Różyczki kalafiora",
+          "cooking_oven_program_dish_automatic_microwave_steambroccoli": "Auto (mikrofalówka): Gotowanie brokułów na parze",
+          "cooking_oven_program_dish_automatic_microwave_steambrusselsprouts": "Auto (mikrofalówka): Gotowanie brukselki na parze",
+          "cooking_oven_program_dish_automatic_microwave_steamcarrots": "Auto (mikrofalówka): Gotowanie marchewki na parze",
+          "cooking_oven_program_dish_automatic_microwave_steamfennel": "Auto (mikrofalówka): Gotowanie kopru włoskiego na parze",
+          "cooking_oven_program_dish_automatic_microwave_steamfishfillet": "Auto (mikrofalówka): Gotowanie filetu rybnego na parze",
+          "cooking_oven_program_dish_automatic_microwave_steamgreenbeans": "Auto (mikrofalówka): Gotowanie fasolki szparagowej na parze",
+          "cooking_oven_program_dish_automatic_microwave_steamkohlrabi": "Auto (mikrofalówka): Gotowanie kalarepy na parze",
+          "cooking_oven_program_dish_automatic_microwave_steampeas": "Auto (mikrofalówka): Gotowanie groszku na parze",
+          "cooking_oven_program_dish_automatic_microwave_steamzucchini": "Auto (mikrofalówka): Gotowanie cukinii na parze",
+          "cooking_oven_program_dish_automatic_microwave_warmupbabyfood": "Auto (mikrofalówka): Podgrzewanie jedzenia dla dzieci",
+          "cooking_oven_program_dish_bakingsensor_applecakecovered": "Czujnik pieczenia: Szarlotka (kryta)",
+          "cooking_oven_program_dish_bakingsensor_applecakeopen": "Czujnik pieczenia: Szarlotka (odkryta)",
+          "cooking_oven_program_dish_bakingsensor_applepie": "Czujnik pieczenia: Szarlotka",
+          "cooking_oven_program_dish_bakingsensor_beefburgers": "Czujnik pieczenia: Burgery wołowe",
+          "cooking_oven_program_dish_bakingsensor_bread": "Czujnik pieczenia: Chleb",
+          "cooking_oven_program_dish_bakingsensor_brownies": "Czujnik pieczenia: Brownie",
+          "cooking_oven_program_dish_bakingsensor_bunschouxbuns": "Czujnik pieczenia: Bułeczki/Ptysie",
+          "cooking_oven_program_dish_bakingsensor_cheesecake": "Czujnik pieczenia: Sernik",
+          "cooking_oven_program_dish_bakingsensor_cheesecaketall": "Czujnik pieczenia: Sernik (wysoki)",
+          "cooking_oven_program_dish_bakingsensor_christmasstollen": "Czujnik pieczenia: Strucla świąteczna",
+          "cooking_oven_program_dish_bakingsensor_creamsponge": "Czujnik pieczenia: Biszkopt ze śmietaną",
+          "cooking_oven_program_dish_bakingsensor_croissantsyeast": "Czujnik pieczenia: Croissanty (drożdżowe)",
+          "cooking_oven_program_dish_bakingsensor_cupcakesmuffins": "Czujnik pieczenia: Babeczki/Muffinki",
+          "cooking_oven_program_dish_bakingsensor_flatbreadpita": "Czujnik pieczenia: Placek płaski/Pita",
+          "cooking_oven_program_dish_bakingsensor_fruitflanbaking": "Czujnik pieczenia: Tarta owocowa",
+          "cooking_oven_program_dish_bakingsensor_gateausponge": "Czujnik pieczenia: Biszkopt tortowy",
+          "cooking_oven_program_dish_bakingsensor_lasagnecooked": "Czujnik pieczenia: Lazania (ugotowana)",
+          "cooking_oven_program_dish_bakingsensor_lasagneraw": "Czujnik pieczenia: Lazania (surowa)",
+          "cooking_oven_program_dish_bakingsensor_loafcake": "Czujnik pieczenia: Ciasto w keksówce",
+          "cooking_oven_program_dish_bakingsensor_marblesponge": "Czujnik pieczenia: Ciasto marmurkowe",
+          "cooking_oven_program_dish_bakingsensor_meatball": "Czujnik pieczenia: Pulpet",
+          "cooking_oven_program_dish_bakingsensor_partcookedbaguettes": "Czujnik pieczenia: Podpieczone bagietki",
+          "cooking_oven_program_dish_bakingsensor_partcookedrolls": "Czujnik pieczenia: Podpieczone bułki",
+          "cooking_oven_program_dish_bakingsensor_pizza": "Czujnik pieczenia: Pizza",
+          "cooking_oven_program_dish_bakingsensor_plainsponge": "Czujnik pieczenia: Biszkopt naturalny",
+          "cooking_oven_program_dish_bakingsensor_potatogratin": "Czujnik pieczenia: Zapiekanka ziemniaczana",
+          "cooking_oven_program_dish_bakingsensor_quiche": "Czujnik pieczenia: Quiche",
+          "cooking_oven_program_dish_bakingsensor_ringcake": "Czujnik pieczenia: Baba/keks pierścieniowy",
+          "cooking_oven_program_dish_bakingsensor_roastbeefmedium": "Czujnik pieczenia: Rostbef (średni)",
+          "cooking_oven_program_dish_bakingsensor_roastbeefrare": "Czujnik pieczenia: Rostbef (krwisty)",
+          "cooking_oven_program_dish_bakingsensor_roastbeefwelldone": "Czujnik pieczenia: Rostbef (wypieczony)",
+          "cooking_oven_program_dish_bakingsensor_rolls": "Czujnik pieczenia: Bułki",
+          "cooking_oven_program_dish_bakingsensor_schweinebraten": "Czujnik pieczenia: Schweinebraten",
+          "cooking_oven_program_dish_bakingsensor_shortcrust": "Czujnik pieczenia: Ciasto kruche",
+          "cooking_oven_program_dish_bakingsensor_smallbiscuits": "Czujnik pieczenia: Małe ciastka",
+          "cooking_oven_program_dish_bakingsensor_souffle": "Czujnik pieczenia: Suflet",
+          "cooking_oven_program_dish_bakingsensor_streuselkuchen": "Czujnik pieczenia: Streuselkuchen",
+          "cooking_oven_program_dish_bakingsensor_swiss_roll": "Czujnik pieczenia: Rolada biszkoptowa",
+          "cooking_oven_program_dish_bakingsensor_tinloaf": "Czujnik pieczenia: Chleb w keksówce",
+          "cooking_oven_program_dish_bakingsensor_veggieburgers": "Czujnik pieczenia: Burgery warzywne",
+          "cooking_oven_program_dish_bakingsensor_whitebread": "Czujnik pieczenia: Chleb biały",
+          "cooking_oven_program_dish_bakingsensor_wholemealspeltbread": "Czujnik pieczenia: Chleb razowy/orkiszowy",
+          "cooking_oven_program_dish_bakingsensor_yeastdough": "Czujnik pieczenia: Ciasto drożdżowe",
+          "cooking_oven_program_dish_meatprobe_beeffiletmedium": "Sonda mięsna: Filet wołowy (średni)",
+          "cooking_oven_program_dish_meatprobe_beeffiletrare": "Sonda mięsna: Filet wołowy (krwisty)",
+          "cooking_oven_program_dish_meatprobe_beeffiletwelldone": "Sonda mięsna: Filet wołowy (wypieczony)",
+          "cooking_oven_program_dish_meatprobe_beefroast": "Sonda mięsna: Pieczeń wołowa",
+          "cooking_oven_program_dish_meatprobe_duckbreast": "Sonda mięsna: Pierś kaczki",
+          "cooking_oven_program_dish_meatprobe_fish": "Sonda mięsna: Ryba",
+          "cooking_oven_program_dish_meatprobe_lamblegbonein": "Sonda mięsna: Udziec jagnięcy z kością",
+          "cooking_oven_program_dish_meatprobe_lamblegboneless": "Sonda mięsna: Udziec jagnięcy bez kości",
+          "cooking_oven_program_dish_meatprobe_lambsaddle": "Sonda mięsna: Comber jagnięcy",
+          "cooking_oven_program_dish_meatprobe_porkbelly": "Sonda mięsna: Boczek wieprzowy",
+          "cooking_oven_program_dish_meatprobe_porkneck": "Sonda mięsna: Karkówka wieprzowa",
+          "cooking_oven_program_dish_meatprobe_porkroast": "Sonda mięsna: Pieczeń wieprzowa",
+          "cooking_oven_program_dish_meatprobe_poultrystuffed": "Sonda mięsna: Drób (nadziewany)",
+          "cooking_oven_program_dish_meatprobe_poultryunstuffed": "Sonda mięsna: Drób (bez nadzienia)",
+          "cooking_oven_program_dish_meatprobe_sirloinsteakmedium": "Sonda mięsna: Stek z rostbefu (średni)",
+          "cooking_oven_program_dish_meatprobe_sirloinsteakrare": "Sonda mięsna: Stek z rostbefu (krwisty)",
+          "cooking_oven_program_dish_meatprobe_sirloinsteakwelldone": "Sonda mięsna: Stek z rostbefu (wypieczony)",
+          "cooking_oven_program_dish_meatprobe_vealroast": "Sonda mięsna: Pieczeń cielęca",
+          "cooking_oven_program_dish_meatprobe_venison": "Sonda mięsna: Dziczyzna",
+          "cooking_oven_program_dish_meatprobe_wildboar": "Sonda mięsna: Dzik",
+          "cooking_oven_program_dish_recommendation_breadrolls": "Rekomendacja: Bułki",
+          "cooking_oven_program_dish_recommendation_cakeoncookingtray": "Rekomendacja: Ciasto na blasze",
+          "cooking_oven_program_dish_recommendation_casserole": "Rekomendacja: Zapiekanka",
+          "cooking_oven_program_dish_recommendation_chips": "Rekomendacja: Frytki",
+          "cooking_oven_program_dish_recommendation_custard": "Rekomendacja: Krem budyniowy",
+          "cooking_oven_program_dish_recommendation_fishsticks": "Rekomendacja: Paluszki rybne",
+          "cooking_oven_program_dish_recommendation_frozenpizza": "Rekomendacja: Pizza mrożona",
+          "cooking_oven_program_dish_recommendation_gratin": "Rekomendacja: Zapiekanka",
+          "cooking_oven_program_dish_recommendation_meringues": "Rekomendacja: Bezy",
+          "cooking_oven_program_dish_recommendation_ovenroast": "Rekomendacja: Pieczeń z piekarnika",
+          "cooking_oven_program_dish_recommendation_poultry": "Rekomendacja: Drób",
+          "cooking_oven_program_dish_recommendation_preserving": "Rekomendacja: Wekowanie",
+          "cooking_oven_program_dish_recommendation_quiche": "Rekomendacja: Quiche",
+          "cooking_oven_program_dish_recommendation_readymealinfan": "Rekomendacja: Danie gotowe (termoobieg)",
+          "cooking_oven_program_dish_recommendation_ringcake": "Rekomendacja: Baba/keks pierścieniowy",
+          "cooking_oven_program_dish_recommendation_souffle": "Rekomendacja: Suflet",
+          "cooking_oven_program_dish_recommendation_swissroll": "Rekomendacja: Rolada biszkoptowa",
+          "cooking_oven_program_dish_recommendation_vegetablegratin": "Rekomendacja: Zapiekanka warzywna",
+          "cooking_oven_program_dish_recommendation_wholemealbreads": "Rekomendacja: Pieczywo razowe",
+          "cooking_oven_program_heatingmode_defrost": "Rozmrażanie",
+          "cooking_oven_program_heatingmode_desiccation": "Suszenie",
+          "cooking_oven_program_heatingmode_proofdough": "Wyrastanie ciasta",
+          "cooking_oven_program_heatingmode_proof": "Wyrastanie ciasta",
+          "cooking_oven_program_heatingmode_convectionbake": "Termoobieg",
+          "cooking_oven_program_heatingmode_steamassist": "Wspomaganie parą",
+          "cooking_oven_program_heatingmode_intensiveheat": "Intensywne ciepło",
+          "cooking_oven_program_heatingmode_fullsurfacegrill": "Grill na całej powierzchni",
+          "cooking_oven_program_heatingmode_economygrill": "Grill ekonomiczny",
+          "cooking_oven_program_heatingmode_circuitedgrill": "Grill obiegowy",
+          "cooking_oven_program_heatingmode_warmingdrawer": "Szuflada do podgrzewania",
+          "cooking_oven_program_microwave_900watt": "Mikrofalówka 900 W",
+          "cooking_oven_program_microwave_1000watt": "Mikrofalówka 1000 W",
+          "cooking_oven_program_subsequentmode_subsequentmicrowavecooking": "Następny tryb: Gotowanie w mikrofalówce",
+          "cooking_oven_program_subsequentmode_subsequentbrowning": "Następny tryb: Przyrumienianie",
+          "cooking_oven_program_subsequentmode_subsequentkeepwarm": "Następny tryb: Podtrzymanie ciepła",
+          "cooking_oven_program_cleaning_descale": "Czyszczenie: Odkamienianie",
+          "cooking_oven_program_cleaning_draining": "Czyszczenie: Odprowadzanie wody",
+          "cooking_oven_program_cleaning_ecolysis": "Czyszczenie: Ekoliza",
+          "cooking_oven_program_cleaning_flushing": "Czyszczenie: Płukanie",
+          "cooking_oven_program_cleaningmodes_autosteamcalibration": "Czyszczenie: Automatyczna kalibracja pary",
+          "cooking_oven_program_heatingmode_airfry": "Air Fry",
+          "cooking_oven_program_heatingmode_grilllargearea": "Grill, duży obszar",
+          "cooking_oven_program_heatingmode_hotairgentle": "Delikatny termoobieg",
+          "cooking_oven_program_heatingmode_letrest": "Odpoczynek",
+          "cooking_oven_program_heatingmode_preheating": "Podgrzewanie wstępne",
+          "cooking_oven_program_dish_automatic_conv_bakeditems": "Auto: Wypieki",
+          "cooking_oven_program_dish_automatic_conv_bonedlegoflambmedium": "Auto: Udziec jagnięcy bez kości (średni)",
+          "cooking_oven_program_dish_automatic_conv_bread": "Auto: Chleb",
+          "cooking_oven_program_dish_automatic_conv_breadrollsbaguette": "Auto: Bułki/Bagietka",
+          "cooking_oven_program_dish_automatic_conv_pastadumplingspotatoesrice": "Auto: Makaron/Pierogi/Ziemniaki/Ryż",
+          "cooking_oven_program_dish_automatic_conv_reheatplatedmeal": "Auto: Podgrzewanie posiłku na talerzu",
+          "cooking_oven_program_dish_automatic_conv_reheatvegetables": "Auto: Podgrzewanie warzyw",
+          "cooking_oven_program_dish_automatic_conv_roastbeefenglish": "Auto: Rostbef po angielsku",
+          "cooking_oven_program_dish_automatic_conv_steam_bonelesslegoflambmedium": "Auto (para): Udziec jagnięcy bez kości (średni)",
+          "cooking_oven_program_dish_automatic_conv_steam_bonelesslegoflambwelldone": "Auto (para): Udziec jagnięcy bez kości (wypieczony)",
+          "cooking_oven_program_dish_automatic_conv_steam_bonelesslegofroevenison": "Auto (para): Udziec sarny bez kości",
+          "cooking_oven_program_dish_automatic_conv_steam_bonelesslegofvenison": "Auto (para): Udziec jelenia bez kości",
+          "cooking_oven_program_dish_automatic_conv_steam_bonelessporkneckjoint": "Auto (para): Karkówka bez kości",
+          "cooking_oven_program_dish_automatic_conv_steam_breastofvealstuffed": "Auto (para): Mostek cielęcy (nadziewany)",
+          "cooking_oven_program_dish_automatic_conv_steam_chickenparts": "Auto (para): Części kurczaka",
+          "cooking_oven_program_dish_automatic_conv_steam_fatlessspongecake": "Auto (para): Biszkopt beztłuszczowy",
+          "cooking_oven_program_dish_automatic_conv_steam_fishfilletgratinated": "Auto (para): Filet rybny zapiekany",
+          "cooking_oven_program_dish_automatic_conv_steam_fishfilletstew": "Auto (para): Filet rybny (duszony)",
+          "cooking_oven_program_dish_automatic_conv_steam_flatbread": "Auto (para): Podpłomyk",
+          "cooking_oven_program_dish_automatic_conv_steam_jointofporkwithcracklingegshoulder": "Auto (para): Łopatka wieprzowa ze skórką",
+          "cooking_oven_program_dish_automatic_conv_steam_jointofveallean": "Auto (para): Cielęcina (chuda)",
+          "cooking_oven_program_dish_automatic_conv_steam_jointofvealmarbled": "Auto (para): Cielęcina (marmurkowa)",
+          "cooking_oven_program_dish_automatic_conv_steam_knuckleofpork": "Auto (para): Golonka wieprzowa",
+          "cooking_oven_program_dish_automatic_conv_steam_knuckleofveal": "Auto (para): Gicz cielęca",
+          "cooking_oven_program_dish_automatic_conv_steam_legoflambonthebonewelldone": "Auto (para): Udziec jagnięcy z kością (wypieczony)",
+          "cooking_oven_program_dish_automatic_conv_steam_meatloafmadefromfreshmincedmeat": "Auto (para): Pieczeń rzymska ze świeżego mięsa mielonego",
+          "cooking_oven_program_dish_automatic_conv_steam_multigrainryebreadwithyeastinaloaftin": "Auto (para): Chleb żytni wieloziarnisty na drożdżach w keksówce",
+          "cooking_oven_program_dish_automatic_conv_steam_pizzawiththickbaseonepizza": "Auto (para): Pizza na grubym cieście (jedna pizza)",
+          "cooking_oven_program_dish_automatic_conv_steam_pizzawiththinbaseonepizza": "Auto (para): Pizza na cienkim cieście (jedna pizza)",
+          "cooking_oven_program_dish_automatic_conv_steam_porkchopfryonthebone": "Auto (para): Kotlet wieprzowy z kością",
+          "cooking_oven_program_dish_automatic_conv_steam_poulardunstuffed": "Auto (para): Pularada (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_steam_roastporkloin": "Auto (para): Pieczeń wieprzowa (schab)",
+          "cooking_oven_program_dish_automatic_conv_steam_roastwholefish": "Auto (para): Pieczona cała ryba",
+          "cooking_oven_program_dish_automatic_conv_steam_rolledporkjoint": "Auto (para): Zwijana pieczeń wieprzowa",
+          "cooking_oven_program_dish_automatic_conv_steam_saddleofvenisononthebone": "Auto (para): Siodło jelenia z kością",
+          "cooking_oven_program_dish_automatic_conv_steam_sirloinmedium": "Auto (para): Rostbef (średni)",
+          "cooking_oven_program_dish_automatic_conv_steam_sirloinrare": "Auto (para): Rostbef (krwisty)",
+          "cooking_oven_program_dish_automatic_conv_steam_smokedporkbonedrolledfry": "Auto (para): Wędzona wieprzowina bez kości, zrolowana",
+          "cooking_oven_program_dish_automatic_conv_steam_smokedporkonthebone": "Auto (para): Wędzona wieprzowina z kością",
+          "cooking_oven_program_dish_automatic_conv_steam_tenderloinmedium": "Auto (para): Polędwica (średnia)",
+          "cooking_oven_program_dish_automatic_conv_steam_topsideandtoprump": "Auto (para): Zrazowa górna i kulka",
+          "cooking_oven_program_dish_automatic_conv_steam_unstuffedchicken": "Auto (para): Kurczak (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_steam_unstuffedduck": "Auto (para): Kaczka (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_steam_unstuffedgoose": "Auto (para): Gęś (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_steam_unstuffedsmallturkey": "Auto (para): Mały indyk (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_steam_vienneseboiledbeef": "Auto (para): Wołowina gotowana po wiedeńsku",
+          "cooking_oven_program_dish_automatic_conv_steam_wheatbreadmultigrainwheatbreadinaloaftin": "Auto (para): Chleb pszenny/wieloziarnisty w foremce",
+          "cooking_oven_program_dish_automatic_conv_steam_wheatbreadmultigrainwheatbreadonabakingtray": "Auto (para): Chleb pszenny/wieloziarnisty na blasze",
+          "cooking_oven_program_dish_automatic_conv_steam_whitebreadinaloaftin": "Auto (para): Chleb biały w foremce",
+          "cooking_oven_program_dish_automatic_conv_steam_whitebreadonabakingtray": "Auto (para): Chleb biały na blasze",
+          "cooking_oven_program_dish_automatic_conv_steam_wholerabbit": "Auto (para): Cały królik",
+          "cooking_oven_program_dish_automatic_conv_steam_wholemealbreadonbakingtray": "Auto (para): Chleb razowy na blasze",
+          "cooking_oven_program_dish_automatic_conv_steam_wildboarroast": "Auto (para): Pieczeń z dzika",
+          "cooking_oven_program_dish_automatic_fullsteam_fishwholesteam": "Auto (pełna para): Ryba w całości",
+          "cooking_oven_program_dish_recommendation_conv_bakesavouryfreshcookedingredients": "Rekomendacja: Zapiekanka wytrawna (świeże/gotowane składniki)",
+          "cooking_oven_program_dish_recommendation_conv_bakesweetfresh": "Rekomendacja: Zapiekanka słodka (świeża)",
+          "cooking_oven_program_dish_recommendation_conv_bakedpotatoes": "Rekomendacja: Pieczone ziemniaki",
+          "cooking_oven_program_dish_recommendation_conv_bakedpotatoeson2levels": "Rekomendacja: Pieczone ziemniaki (2 poziomy)",
+          "cooking_oven_program_dish_recommendation_conv_baklava": "Rekomendacja: Baklava",
+          "cooking_oven_program_dish_recommendation_conv_biscuits": "Rekomendacja: Herbatniki",
+          "cooking_oven_program_dish_recommendation_conv_blindbakepastrybase": "Rekomendacja: Podpiekanie ciasta",
+          "cooking_oven_program_dish_recommendation_conv_boerek": "Rekomendacja: Börek",
+          "cooking_oven_program_dish_recommendation_conv_bonlessrolledshoulder": "Rekomendacja: Zwijana łopatka bez kości",
+          "cooking_oven_program_dish_recommendation_conv_breadrolls": "Rekomendacja: Bułki",
+          "cooking_oven_program_dish_recommendation_conv_breadrollsfrozen": "Rekomendacja: Bułki (mrożone)",
+          "cooking_oven_program_dish_recommendation_conv_breastofvealstuffed": "Rekomendacja: Mostek cielęcy (nadziewany)",
+          "cooking_oven_program_dish_recommendation_conv_cannelloni": "Rekomendacja: Cannelloni",
+          "cooking_oven_program_dish_recommendation_conv_chickenbreastfillet": "Rekomendacja: Filet z piersi kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_chickenbreastfilletgrill": "Rekomendacja: Filet z piersi kurczaka (grill)",
+          "cooking_oven_program_dish_recommendation_conv_chickendrumsticks": "Rekomendacja: Podudzia kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_chickengoujonsnuggets": "Rekomendacja: Goujons/Nuggets z kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_chickenparts": "Rekomendacja: Części kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_chilledlasagne": "Rekomendacja: Lazania (schłodzona)",
+          "cooking_oven_program_dish_recommendation_conv_chilledpasta": "Rekomendacja: Makaron schłodzony",
+          "cooking_oven_program_dish_recommendation_conv_chips": "Rekomendacja: Frytki",
+          "cooking_oven_program_dish_recommendation_conv_chouxpastry": "Rekomendacja: Ciasto parzone",
+          "cooking_oven_program_dish_recommendation_conv_ciabatta": "Rekomendacja: Ciabatta",
+          "cooking_oven_program_dish_recommendation_conv_croissantsdough": "Rekomendacja: Croissanty",
+          "cooking_oven_program_dish_recommendation_conv_croquettes": "Rekomendacja: Krokiety",
+          "cooking_oven_program_dish_recommendation_conv_danishpastry": "Rekomendacja: Duńskie wypieki",
+          "cooking_oven_program_dish_recommendation_conv_duckbreast": "Rekomendacja: Pierś kaczki",
+          "cooking_oven_program_dish_recommendation_conv_empanada": "Rekomendacja: Empanada",
+          "cooking_oven_program_dish_recommendation_conv_fatlessspongecake": "Rekomendacja: Biszkopt beztłuszczowy",
+          "cooking_oven_program_dish_recommendation_conv_fishfilletstew": "Rekomendacja: Filet rybny (duszony)",
+          "cooking_oven_program_dish_recommendation_conv_flatbread": "Rekomendacja: Podpłomyk",
+          "cooking_oven_program_dish_recommendation_conv_freshbreadrolls": "Rekomendacja: Świeże bułki",
+          "cooking_oven_program_dish_recommendation_conv_freshlasagne": "Rekomendacja: Świeża lazania",
+          "cooking_oven_program_dish_recommendation_conv_freshsweetbreadrolls": "Rekomendacja: Słodkie bułki",
+          "cooking_oven_program_dish_recommendation_conv_fruitcrumble": "Rekomendacja: Crumble owocowy",
+          "cooking_oven_program_dish_recommendation_conv_fruittartorcheesecakewithpastrybase": "Rekomendacja: Tarta owocowa lub sernik z ciastem",
+          "cooking_oven_program_dish_recommendation_conv_gammonjoint": "Rekomendacja: Szynka wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_goosestuffed": "Rekomendacja: Gęś (nadziewana)",
+          "cooking_oven_program_dish_recommendation_conv_halvedchicken": "Rekomendacja: Połówka kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_hashbrowns": "Rekomendacja: Hash Browns",
+          "cooking_oven_program_dish_recommendation_conv_hashbrownsgb": "Rekomendacja: Hash Browns (GB)",
+          "cooking_oven_program_dish_recommendation_conv_jamtarts": "Rekomendacja: Tartaletki z dżemem",
+          "cooking_oven_program_dish_recommendation_conv_jamtarts2levels": "Rekomendacja: Tartaletki z dżemem (2 poziomy)",
+          "cooking_oven_program_dish_recommendation_conv_knuckleofpork": "Rekomendacja: Golonka wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_lambkarree": "Rekomendacja: Karczek jagnięcy",
+          "cooking_oven_program_dish_recommendation_conv_lasagnefrozen": "Rekomendacja: Lazania (mrożona)",
+          "cooking_oven_program_dish_recommendation_conv_leavenedcake": "Rekomendacja: Ciasto drożdżowe",
+          "cooking_oven_program_dish_recommendation_conv_loinjoint": "Rekomendacja: Polędwica wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_macaroons": "Rekomendacja: Makaroniki",
+          "cooking_oven_program_dish_recommendation_conv_meringue": "Rekomendacja: Beza",
+          "cooking_oven_program_dish_recommendation_conv_minipizzas": "Rekomendacja: Mini pizze",
+          "cooking_oven_program_dish_recommendation_conv_muffins": "Rekomendacja: Muffinki",
+          "cooking_oven_program_dish_recommendation_conv_partcookedbreadrollsorbaguette": "Rekomendacja: Podpieczone bułki lub bagietki",
+          "cooking_oven_program_dish_recommendation_conv_partcookedbreadrollsorbaguettefrozen": "Rekomendacja: Podpieczone bułki lub bagietki (mrożone)",
+          "cooking_oven_program_dish_recommendation_conv_pierogi": "Rekomendacja: Pierogi",
+          "cooking_oven_program_dish_recommendation_conv_pipedcookies": "Rekomendacja: Ciasteczka z rękawa",
+          "cooking_oven_program_dish_recommendation_conv_pizzabaguettefrozen": "Rekomendacja: Pizza bagietka (mrożona)",
+          "cooking_oven_program_dish_recommendation_conv_pizzachilled": "Rekomendacja: Pizza (schłodzona)",
+          "cooking_oven_program_dish_recommendation_conv_pizzafreshonbakingtray": "Rekomendacja: Pizza (świeża, na blasze)",
+          "cooking_oven_program_dish_recommendation_conv_pizzafreshthinbaseinpizzatray": "Rekomendacja: Pizza (świeża, cienkie ciasto, na tacy)",
+          "cooking_oven_program_dish_recommendation_conv_pizzathickcrust1slicefrozen": "Rekomendacja: Pizza gruby spód 1 kawałek (mrożona)",
+          "cooking_oven_program_dish_recommendation_conv_pizzathincrust1slice": "Rekomendacja: Pizza cienki spód 1 kawałek",
+          "cooking_oven_program_dish_recommendation_conv_porkroast": "Rekomendacja: Pieczeń wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_potatogratinrawingredients4cmdeep": "Rekomendacja: Gratin ziemniaczany (surowe składniki, 4 cm)",
+          "cooking_oven_program_dish_recommendation_conv_potatopocketsfilled": "Rekomendacja: Nadziewane kieszonki ziemniaczane",
+          "cooking_oven_program_dish_recommendation_conv_potatowedges": "Rekomendacja: Ćwiartki ziemniaków",
+          "cooking_oven_program_dish_recommendation_conv_pretzelsdough": "Rekomendacja: Precle",
+          "cooking_oven_program_dish_recommendation_conv_puffpastry": "Rekomendacja: Ciasto francuskie",
+          "cooking_oven_program_dish_recommendation_conv_quichetart": "Rekomendacja: Quiche/Tarta",
+          "cooking_oven_program_dish_recommendation_conv_richfruitcake": "Rekomendacja: Ciasto owocowe",
+          "cooking_oven_program_dish_recommendation_conv_roasthalvedpotatoes": "Rekomendacja: Pieczone połówki ziemniaków",
+          "cooking_oven_program_dish_recommendation_conv_roastwholefish": "Rekomendacja: Pieczona cała ryba",
+          "cooking_oven_program_dish_recommendation_conv_roastbeefmedium": "Rekomendacja: Rostbef (średni)",
+          "cooking_oven_program_dish_recommendation_conv_rolledturkeyjoint": "Rekomendacja: Zwijana pieczeń z indyka",
+          "cooking_oven_program_dish_recommendation_conv_saddleofveal": "Rekomendacja: Siodło cielęce",
+          "cooking_oven_program_dish_recommendation_conv_saddleofvenisononthebone": "Rekomendacja: Siodło jelenia z kością",
+          "cooking_oven_program_dish_recommendation_conv_savarinplaitedloaf": "Rekomendacja: Savarin/Warkocz",
+          "cooking_oven_program_dish_recommendation_conv_scones": "Rekomendacja: Scones",
+          "cooking_oven_program_dish_recommendation_conv_scones2levels": "Rekomendacja: Scones (2 poziomy)",
+          "cooking_oven_program_dish_recommendation_conv_shortcrustpastrydishes": "Rekomendacja: Dania z kruchego ciasta",
+          "cooking_oven_program_dish_recommendation_conv_shortcrustpastryflanbase": "Rekomendacja: Spód tarty z kruchego ciasta",
+          "cooking_oven_program_dish_recommendation_conv_shortcrustpastrywithmoisttopping": "Rekomendacja: Kruche ciasto z wilgotnym nadzieniem",
+          "cooking_oven_program_dish_recommendation_conv_shoulderonthebone": "Rekomendacja: Łopatka z kością",
+          "cooking_oven_program_dish_recommendation_conv_simplespongecake": "Rekomendacja: Proste ciasto biszkoptowe",
+          "cooking_oven_program_dish_recommendation_conv_slicesofmeatinsauceegschnitzelstew": "Rekomendacja: Plastry mięsa w sosie (sznycel/gulasz)",
+          "cooking_oven_program_dish_recommendation_conv_smallcakes": "Rekomendacja: Małe ciastka",
+          "cooking_oven_program_dish_recommendation_conv_smallcakes2levels": "Rekomendacja: Małe ciastka (2 poziomy)",
+          "cooking_oven_program_dish_recommendation_conv_soufflesinindividualmolds": "Rekomendacja: Soufflé w foremkach",
+          "cooking_oven_program_dish_recommendation_conv_spongecakewithdrytopping": "Rekomendacja: Biszkopt z suchym nadzieniem",
+          "cooking_oven_program_dish_recommendation_conv_spongecakewithmoisttopping": "Rekomendacja: Biszkopt z wilgotnym nadzieniem",
+          "cooking_oven_program_dish_recommendation_conv_spongeflanbase": "Rekomendacja: Spód biszkoptowy",
+          "cooking_oven_program_dish_recommendation_conv_spongefruitflan": "Rekomendacja: Biszkopt z owocami",
+          "cooking_oven_program_dish_recommendation_conv_squidringsbreaded": "Rekomendacja: Panierowane pierścienie kalmara",
+          "cooking_oven_program_dish_recommendation_conv_stuffedchicken": "Rekomendacja: Nadziewany kurczak",
+          "cooking_oven_program_dish_recommendation_conv_stuffedduck": "Rekomendacja: Nadziewana kaczka",
+          "cooking_oven_program_dish_recommendation_conv_stuffedvegetables": "Rekomendacja: Nadziewane warzywa",
+          "cooking_oven_program_dish_recommendation_conv_sweetstrudel": "Rekomendacja: Słodki strudel",
+          "cooking_oven_program_dish_recommendation_conv_swissroll": "Rekomendacja: Rolada biszkoptowa",
+          "cooking_oven_program_dish_recommendation_conv_swissrollgb": "Rekomendacja: Rolada biszkoptowa (GB)",
+          "cooking_oven_program_dish_recommendation_conv_tart": "Rekomendacja: Tarta",
+          "cooking_oven_program_dish_recommendation_conv_tarteflambee": "Rekomendacja: Tarte Flambée",
+          "cooking_oven_program_dish_recommendation_conv_tenderloinmedium": "Rekomendacja: Polędwica (średnia)",
+          "cooking_oven_program_dish_recommendation_conv_topsideandtoprump": "Rekomendacja: Zrazowa górna i kulka",
+          "cooking_oven_program_dish_recommendation_conv_turkeycrownbritishstyle": "Rekomendacja: Korona indyka (brytyjski styl)",
+          "cooking_oven_program_dish_recommendation_conv_vegetablesaugratin": "Rekomendacja: Warzywa au gratin",
+          "cooking_oven_program_dish_recommendation_conv_victoriaspongecake": "Rekomendacja: Biszkopt Victoria",
+          "cooking_oven_program_dish_recommendation_conv_victoriaspongecake2levels": "Rekomendacja: Biszkopt Victoria (2 poziomy)",
+          "cooking_oven_program_dish_recommendation_conv_volauvents": "Rekomendacja: Vol-au-Vents",
+          "cooking_oven_program_dish_recommendation_conv_wheatbreadmultigrainwheatbreadinaloaftin": "Rekomendacja: Chleb pszenny/wieloziarnisty w foremce",
+          "cooking_oven_program_dish_recommendation_conv_wheatbreadmultigrainwheatbreadonabakingtray": "Rekomendacja: Chleb pszenny/wieloziarnisty na blasze",
+          "cooking_oven_program_dish_recommendation_conv_whitebread": "Rekomendacja: Chleb biały",
+          "cooking_oven_program_dish_recommendation_conv_whitebreadinaloaftin": "Rekomendacja: Chleb biały w foremce",
+          "cooking_oven_program_dish_recommendation_conv_whitebreadonabakingtray": "Rekomendacja: Chleb biały na blasze",
+          "cooking_oven_program_dish_recommendation_conv_wholebakedpotatoes": "Rekomendacja: Pieczone całe ziemniaki",
+          "cooking_oven_program_dish_recommendation_conv_wholechicken": "Rekomendacja: Cały kurczak",
+          "cooking_oven_program_dish_recommendation_conv_yeastcakewithdrytopping": "Rekomendacja: Ciasto drożdżowe z suchym nadzieniem",
+          "cooking_oven_program_dish_recommendation_conv_yeastcakewithmoisttopping": "Rekomendacja: Ciasto drożdżowe z wilgotnym nadzieniem",
+          "cooking_oven_program_dish_recommendation_conv_yeastleavenedbundtcake": "Rekomendacja: Babka drożdżowa",
+          "cooking_oven_program_dish_recommendation_conv_yogurtinglassjars": "Rekomendacja: Jogurt w słoiczkach",
+          "cooking_oven_program_dish_recommendation_conv_yorkshirepudding": "Rekomendacja: Yorkshire Pudding",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_bonelesslegoflambmedium": "Sonda mięsna: Udziec jagnięcy bez kości (średni)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_bonelesslegoflambwelldone": "Sonda mięsna: Udziec jagnięcy bez kości (wypieczony)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_bonelessporkneckjoint": "Sonda mięsna: Karkówka bez kości",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_breastofvealstuffed": "Sonda mięsna: Mostek cielęcy (nadziewany)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_chickenbreastfillet": "Sonda mięsna: Filet z piersi kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_duckbreast": "Sonda mięsna: Pierś kaczki",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_goosebreast": "Sonda mięsna: Pierś gęsi",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_gooselegs": "Sonda mięsna: Udka gęsi",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_jointofporkwithcracklingegshoulder": "Sonda mięsna: Łopatka wieprzowa ze skórką",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_jointofveallean": "Sonda mięsna: Cielęcina (chuda)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_jointofvealmarbled": "Sonda mięsna: Cielęcina (marmurkowa)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_knuckleofpork": "Sonda mięsna: Golonka wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_knuckleofveal": "Sonda mięsna: Gicz cielęca",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_legoflambonthebonewelldone": "Sonda mięsna: Udziec jagnięcy z kością (wypieczony)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_loinjoint": "Sonda mięsna: Polędwica wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_meatloafmadefromfreshmincedmeat": "Sonda mięsna: Pieczeń rzymska ze świeżego mięsa mielonego",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_poulardunstuffed": "Sonda mięsna: Pularada (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_roastjoint": "Sonda mięsna: Pieczona pieczeń",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_roastporkchoponthebone": "Sonda mięsna: Kotlet wieprzowy z kością",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_roastporkloin": "Sonda mięsna: Pieczeń wieprzowa (schab)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_roastwholefish": "Sonda mięsna: Pieczona cała ryba",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_rolledporkjoint": "Sonda mięsna: Zwijana pieczeń wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_rolledturkeyjoint": "Sonda mięsna: Zwijana pieczeń z indyka",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_saddleofveal": "Sonda mięsna: Siodło cielęce",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_sirloinmedium": "Sonda mięsna: Rostbef (średni)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_sirloinrare": "Sonda mięsna: Rostbef (krwisty)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_stuffedchicken": "Sonda mięsna: Nadziewany kurczak",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_tenderloinmedium": "Sonda mięsna: Polędwica (średnia)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_turkeybreast": "Sonda mięsna: Pierś indyka",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_unstuffedchicken": "Sonda mięsna: Kurczak (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_unstuffedsmallturkey": "Sonda mięsna: Mały indyk (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_steam_bakesavouryfreshcookedingredients": "Rekomendacja (para): Zapiekanka wytrawna (świeże/gotowane składniki)",
+          "cooking_oven_program_dish_recommendation_conv_steam_bakesweetfresh": "Rekomendacja (para): Zapiekanka słodka (świeża)",
+          "cooking_oven_program_dish_recommendation_conv_steam_baklava": "Rekomendacja (para): Baklava",
+          "cooking_oven_program_dish_recommendation_conv_steam_cannelloni": "Rekomendacja (para): Cannelloni",
+          "cooking_oven_program_dish_recommendation_conv_steam_chouxpastry": "Rekomendacja (para): Ciasto parzone",
+          "cooking_oven_program_dish_recommendation_conv_steam_ciabatta": "Rekomendacja (para): Ciabatta",
+          "cooking_oven_program_dish_recommendation_conv_steam_croissantsdough": "Rekomendacja (para): Croissanty",
+          "cooking_oven_program_dish_recommendation_conv_steam_danishpastry": "Rekomendacja (para): Duńskie wypieki",
+          "cooking_oven_program_dish_recommendation_conv_steam_duckbreast": "Rekomendacja (para): Pierś kaczki",
+          "cooking_oven_program_dish_recommendation_conv_steam_filletofpork": "Rekomendacja (para): Polędwiczka wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_steam_freshbreadrolls": "Rekomendacja (para): Świeże bułki",
+          "cooking_oven_program_dish_recommendation_conv_steam_freshlasagne": "Rekomendacja (para): Świeża lazania",
+          "cooking_oven_program_dish_recommendation_conv_steam_freshsweetbreadrolls": "Rekomendacja (para): Słodkie bułki",
+          "cooking_oven_program_dish_recommendation_conv_steam_gooselegs": "Rekomendacja (para): Udka gęsi",
+          "cooking_oven_program_dish_recommendation_conv_steam_goosestuffed": "Rekomendacja (para): Gęś (nadziewana)",
+          "cooking_oven_program_dish_recommendation_conv_steam_halvedchicken": "Rekomendacja (para): Połówka kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_steam_lasagnefrozen": "Rekomendacja (para): Lazania (mrożona)",
+          "cooking_oven_program_dish_recommendation_conv_steam_leavenedcake": "Rekomendacja (para): Ciasto drożdżowe",
+          "cooking_oven_program_dish_recommendation_conv_steam_partcookedbreadrollsorbaguette": "Rekomendacja (para): Podpieczone bułki lub bagietki",
+          "cooking_oven_program_dish_recommendation_conv_steam_partcookedrollsorbaguettefrozen": "Rekomendacja (para): Podpieczone bułki lub bagietki (mrożone)",
+          "cooking_oven_program_dish_recommendation_conv_steam_potatogratinrawingredients4cmdeep": "Rekomendacja (para): Gratin ziemniaczany (surowe składniki, 4 cm)",
+          "cooking_oven_program_dish_recommendation_conv_steam_pretzelsdough": "Rekomendacja (para): Precle",
+          "cooking_oven_program_dish_recommendation_conv_steam_puffpastry": "Rekomendacja (para): Ciasto francuskie",
+          "cooking_oven_program_dish_recommendation_conv_steam_rolledturkeyjoint": "Rekomendacja (para): Zwijana pieczeń z indyka",
+          "cooking_oven_program_dish_recommendation_conv_steam_saddleofveal": "Rekomendacja (para): Siodło cielęce",
+          "cooking_oven_program_dish_recommendation_conv_steam_savarinplaitedloaf": "Rekomendacja (para): Savarin/Warkocz",
+          "cooking_oven_program_dish_recommendation_conv_steam_stuffedchicken": "Rekomendacja (para): Nadziewany kurczak",
+          "cooking_oven_program_dish_recommendation_conv_steam_stuffedduck": "Rekomendacja (para): Nadziewana kaczka",
+          "cooking_oven_program_dish_recommendation_conv_steam_sweetstrudel": "Rekomendacja (para): Słodki strudel",
+          "cooking_oven_program_dish_recommendation_conv_steam_turkeybreast": "Rekomendacja (para): Pierś indyka",
+          "cooking_oven_program_dish_recommendation_conv_steam_turkeythigh": "Rekomendacja (para): Udziec z indyka",
+          "cooking_oven_program_dish_recommendation_conv_steam_whitebread": "Rekomendacja (para): Chleb biały",
+          "cooking_oven_program_dish_recommendation_conv_steam_yeastleavenedbundtcake": "Rekomendacja (para): Babka drożdżowa",
+          "cooking_oven_program_dish_recommendation_conv_steam_yeaststollen": "Rekomendacja (para): Strucla drożdżowa",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_bonelesslegoflambmedium": "Sonda mięsna (para): Udziec jagnięcy bez kości (średni)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_bonelesslegoflambwelldone": "Sonda mięsna (para): Udziec jagnięcy bez kości (wypieczony)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_bonelessporkneckjoint": "Sonda mięsna (para): Karkówka bez kości",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_breastofvealstuffed": "Sonda mięsna (para): Mostek cielęcy (nadziewany)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_duckbreast": "Sonda mięsna (para): Pierś kaczki",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_filletofpork": "Sonda mięsna (para): Polędwiczka wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_gooselegs": "Sonda mięsna (para): Udka gęsi",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_halvedchicken": "Sonda mięsna (para): Połówka kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_jointofveallean": "Sonda mięsna (para): Cielęcina (chuda)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_jointofvealmarbled": "Sonda mięsna (para): Cielęcina (marmurkowa)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_knuckleofveal": "Sonda mięsna (para): Gicz cielęca",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_legoflambonthebonewelldone": "Sonda mięsna (para): Udziec jagnięcy z kością (wypieczony)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_meatloafmadefromfreshmincedmeat": "Sonda mięsna (para): Pieczeń rzymska ze świeżego mięsa mielonego",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_poulardunstuffed": "Sonda mięsna (para): Pularada (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_roastporkchoponthebone": "Sonda mięsna (para): Kotlet wieprzowy z kością",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_roastporkloin": "Sonda mięsna (para): Pieczeń wieprzowa (schab)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_rolledporkjoint": "Sonda mięsna (para): Zwijana pieczeń wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_rolledturkeyjoint": "Sonda mięsna (para): Zwijana pieczeń z indyka",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_saddleofveal": "Sonda mięsna (para): Siodło cielęce",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_sirloinmedium": "Sonda mięsna (para): Rostbef (średni)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_sirloinrare": "Sonda mięsna (para): Rostbef (krwisty)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_smokedporkonthebone": "Sonda mięsna (para): Wędzona wieprzowina z kością",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_tenderloinmedium": "Sonda mięsna (para): Polędwica (średnia)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_turkeybreast": "Sonda mięsna (para): Pierś indyka",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_turkeythigh": "Sonda mięsna (para): Udziec z indyka",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_unstuffedchicken": "Sonda mięsna (para): Kurczak (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_unstuffedduck": "Sonda mięsna (para): Kaczka (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_unstuffedgoose": "Sonda mięsna (para): Gęś (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_unstuffedsmallturkey": "Sonda mięsna (para): Mały indyk (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_fullsteam_applesinslices5mm": "Pełna para: Jabłka w plastrach 5mm",
+          "cooking_oven_program_dish_recommendation_fullsteam_basmatirice": "Pełna para: Ryż basmati",
+          "cooking_oven_program_dish_recommendation_fullsteam_beans": "Pełna para: Fasola",
+          "cooking_oven_program_dish_recommendation_fullsteam_beetrootwholesteam": "Pełna para: Burak w całości",
+          "cooking_oven_program_dish_recommendation_fullsteam_bluemussels": "Pełna para: Małże",
+          "cooking_oven_program_dish_recommendation_fullsteam_boiledpotatoes": "Pełna para: Ziemniaki gotowane",
+          "cooking_oven_program_dish_recommendation_fullsteam_boiledpotatoeswskinlarge": "Pełna para: Ziemniaki gotowane w mundurkach (duże)",
+          "cooking_oven_program_dish_recommendation_fullsteam_boiledpotatoeswskinmedium": "Pełna para: Ziemniaki gotowane w mundurkach (średnie)",
+          "cooking_oven_program_dish_recommendation_fullsteam_boiledpotatoeswskinsmall": "Pełna para: Ziemniaki gotowane w mundurkach (małe)",
+          "cooking_oven_program_dish_recommendation_fullsteam_boiledsausages": "Pełna para: Parówki gotowane",
+          "cooking_oven_program_dish_recommendation_fullsteam_broccoli": "Pełna para: Brokuły",
+          "cooking_oven_program_dish_recommendation_fullsteam_brownrice": "Pełna para: Ryż brązowy",
+          "cooking_oven_program_dish_recommendation_fullsteam_brusselssprouts": "Pełna para: Brukselka",
+          "cooking_oven_program_dish_recommendation_fullsteam_canellinibeanspresoftened": "Pełna para: Fasola Cannellini (wstępnie namoczona)",
+          "cooking_oven_program_dish_recommendation_fullsteam_carrots": "Pełna para: Marchewka",
+          "cooking_oven_program_dish_recommendation_fullsteam_cauliflower": "Pełna para: Kalafior",
+          "cooking_oven_program_dish_recommendation_fullsteam_cauliflowerfloretssteam": "Pełna para: Różyczki kalafiora",
+          "cooking_oven_program_dish_recommendation_fullsteam_chickenbreastfilletsteam": "Pełna para: Filet z piersi kurczaka",
+          "cooking_oven_program_dish_recommendation_fullsteam_cod": "Pełna para: Dorsz",
+          "cooking_oven_program_dish_recommendation_fullsteam_codcutlet": "Pełna para: Kotlet z dorsza",
+          "cooking_oven_program_dish_recommendation_fullsteam_couscous": "Pełna para: Kuskus",
+          "cooking_oven_program_dish_recommendation_fullsteam_cremecaramel": "Pełna para: Crème Caramel",
+          "cooking_oven_program_dish_recommendation_fullsteam_defrostberries": "Pełna para: Rozmrażanie owoców jagodowych",
+          "cooking_oven_program_dish_recommendation_fullsteam_defrostinblockfrozenvegetables": "Pełna para: Rozmrażanie warzyw mrożonych w bloku",
+          "cooking_oven_program_dish_recommendation_fullsteam_defrostloosevegetables": "Pełna para: Rozmrażanie warzyw luzem",
+          "cooking_oven_program_dish_recommendation_fullsteam_dumplings": "Pełna para: Pierogi/Kluski",
+          "cooking_oven_program_dish_recommendation_fullsteam_fishfilletfreshsteam": "Pełna para: Filet rybny (świeży)",
+          "cooking_oven_program_dish_recommendation_fullsteam_fishterrine": "Pełna para: Terrina rybna",
+          "cooking_oven_program_dish_recommendation_fullsteam_frozenfishfillet": "Pełna para: Filet rybny (mrożony)",
+          "cooking_oven_program_dish_recommendation_fullsteam_fruitcompote": "Pełna para: Kompot owocowy",
+          "cooking_oven_program_dish_recommendation_fullsteam_greenasparagus": "Pełna para: Zielone szparagi",
+          "cooking_oven_program_dish_recommendation_fullsteam_greenbeanssteam": "Pełna para: Fasolka szparagowa",
+          "cooking_oven_program_dish_recommendation_fullsteam_halibut": "Pełna para: Halibut",
+          "cooking_oven_program_dish_recommendation_fullsteam_halibutcutlet": "Pełna para: Kotlet z halibuta",
+          "cooking_oven_program_dish_recommendation_fullsteam_hardboiledeggs": "Pełna para: Jajka na twardo",
+          "cooking_oven_program_dish_recommendation_fullsteam_lentils": "Pełna para: Soczewica",
+          "cooking_oven_program_dish_recommendation_fullsteam_longgrainrice": "Pełna para: Ryż długoziarnisty",
+          "cooking_oven_program_dish_recommendation_fullsteam_meatprobe_chickenbreastfilletsteam": "Sonda mięsna (pełna para): Filet z piersi kurczaka",
+          "cooking_oven_program_dish_recommendation_fullsteam_meatprobe_fishwholesteam": "Sonda mięsna (pełna para): Ryba w całości",
+          "cooking_oven_program_dish_recommendation_fullsteam_millet": "Pełna para: Kasza jaglana",
+          "cooking_oven_program_dish_recommendation_fullsteam_mixedvegetablesfrozen": "Pełna para: Warzywa mieszane (mrożone)",
+          "cooking_oven_program_dish_recommendation_fullsteam_monkfish": "Pełna para: Żabnica",
+          "cooking_oven_program_dish_recommendation_fullsteam_parboiledrice": "Pełna para: Ryż parboiled",
+          "cooking_oven_program_dish_recommendation_fullsteam_pearlbarley": "Pełna para: Kasza perłowa",
+          "cooking_oven_program_dish_recommendation_fullsteam_peas": "Pełna para: Groszek",
+          "cooking_oven_program_dish_recommendation_fullsteam_pineappleinslices1to2cm": "Pełna para: Ananas w plastrach 1-2cm",
+          "cooking_oven_program_dish_recommendation_fullsteam_pipfruits": "Pełna para: Owoce ziarnkowe",
+          "cooking_oven_program_dish_recommendation_fullsteam_polenta": "Pełna para: Polenta",
+          "cooking_oven_program_dish_recommendation_fullsteam_prawns": "Pełna para: Krewetki",
+          "cooking_oven_program_dish_recommendation_fullsteam_pumpkin": "Pełna para: Dynia",
+          "cooking_oven_program_dish_recommendation_fullsteam_raspberries": "Pełna para: Maliny",
+          "cooking_oven_program_dish_recommendation_fullsteam_redcurrants": "Pełna para: Czerwone porzeczki",
+          "cooking_oven_program_dish_recommendation_fullsteam_ricepudding": "Pełna para: Ryż na mleku",
+          "cooking_oven_program_dish_recommendation_fullsteam_risotto": "Pełna para: Risotto",
+          "cooking_oven_program_dish_recommendation_fullsteam_royale": "Pełna para: Royale",
+          "cooking_oven_program_dish_recommendation_fullsteam_salmon": "Pełna para: Łosoś",
+          "cooking_oven_program_dish_recommendation_fullsteam_salmoncutlet": "Pełna para: Kotlet z łososia",
+          "cooking_oven_program_dish_recommendation_fullsteam_salmonfillet": "Pełna para: Filet z łososia",
+          "cooking_oven_program_dish_recommendation_fullsteam_seabass": "Pełna para: Okoń morski",
+          "cooking_oven_program_dish_recommendation_fullsteam_semolinadumplings": "Pełna para: Kluski manne",
+          "cooking_oven_program_dish_recommendation_fullsteam_softboiledeggs": "Pełna para: Jajka na miękko",
+          "cooking_oven_program_dish_recommendation_fullsteam_softwheatwhole": "Pełna para: Pszenica zwyczajna (ziarno)",
+          "cooking_oven_program_dish_recommendation_fullsteam_solerollsstuffed": "Pełna para: Rulony z soli (nadziewane)",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamartichokes": "Pełna para: Karczochy",
+          "cooking_oven_program_dish_recommendation_fullsteam_steambroccoliflorets": "Pełna para: Różyczki brokuła",
+          "cooking_oven_program_dish_recommendation_fullsteam_steambrusselssprouts": "Pełna para: Brukselka",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamgreenasparagus": "Pełna para: Zielone szparagi",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamleeksinrings": "Pełna para: Pory w krążkach",
+          "cooking_oven_program_dish_recommendation_fullsteam_steammangetout": "Pełna para: Groszek cukrowy",
+          "cooking_oven_program_dish_recommendation_fullsteam_steampeas": "Pełna para: Groszek",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamshreddedredcabbage": "Pełna para: Czerwona kapusta szatkowana",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamshreddedswisschard": "Pełna para: Boćwina szatkowana",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamshreddedwhitecabbage": "Pełna para: Biała kapusta szatkowana",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamslicedcarrots": "Pełna para: Marchewka w plastrach",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamslicedcourgettes": "Pełna para: Cukinia w plastrach",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamslicedfennel": "Pełna para: Koper włoski w plastrach",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamslicedkohlrabi": "Pełna para: Kalarepa w plastrach",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamspinach": "Pełna para: Szpinak",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamvegetableflan": "Pełna para: Tarta warzywna",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamwhiteasparagus": "Pełna para: Szparagi białe",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamwholecauliflower": "Pełna para: Kalafior w całości",
+          "cooking_oven_program_dish_recommendation_fullsteam_sterilisingbottles": "Pełna para: Sterylizacja butelek",
+          "cooking_oven_program_dish_recommendation_fullsteam_stonefruits": "Pełna para: Owoce pestkowe",
+          "cooking_oven_program_dish_recommendation_fullsteam_tomatoes": "Pełna para: Pomidory",
+          "cooking_oven_program_dish_recommendation_fullsteam_trout": "Pełna para: Pstrąg",
+          "cooking_oven_program_dish_recommendation_fullsteam_turbot": "Pełna para: Turbot",
+          "cooking_oven_program_dish_recommendation_fullsteam_turbotcutlet": "Pełna para: Kotlet z turbota",
+          "cooking_oven_program_dish_recommendation_fullsteam_unripespeltgraincoarseground": "Pełna para: Niedojrzałe ziarno orkiszu, grubo mielone",
+          "cooking_oven_program_dish_recommendation_fullsteam_vanillasauce": "Pełna para: Sos waniliowy",
+          "cooking_oven_program_dish_recommendation_fullsteam_vegetables": "Pełna para: Warzywa",
+          "cooking_oven_program_dish_recommendation_fullsteam_wholewheat": "Pełna para: Pszenica pełnoziarnista",
+          "cooking_oven_program_dish_recommendation_fullsteam_yeastdumplings": "Pełna para: Knedle drożdżowe",
+          "cooking_oven_program_dish_sousvide_fullsteam_beeforvealfiletmedallions3to4cm": "Sous Vide: Medaliony z filetu wołowego lub cielęcego 3-4cm",
+          "cooking_oven_program_dish_sousvide_fullsteam_beeforvealsteak": "Sous Vide: Stek wołowy lub cielęcy",
+          "cooking_oven_program_dish_sousvide_fullsteam_chickenbreastfillet": "Sous Vide: Filet z piersi kurczaka",
+          "cooking_oven_program_dish_sousvide_fullsteam_duckbreast": "Sous Vide: Pierś kaczki",
+          "cooking_oven_program_dish_sousvide_fullsteam_fishfillet": "Sous Vide: Filet rybny",
+          "cooking_oven_program_dish_sousvide_fullsteam_porkfiletmedaillions4to5cm": "Sous Vide: Medaliony z polędwicy wieprzowej 4-5cm",
+          "cooking_oven_program_dish_sousvide_fullsteam_prawns": "Sous Vide: Krewetki",
+          "cooking_oven_program_dish_sousvide_fullsteam_saddleoflamb": "Sous Vide: Comber jagnięcy",
+          "cooking_oven_program_dish_sousvide_fullsteam_scallops": "Sous Vide: Przegrzebki",
+          "cooking_oven_program_steammodes_defrosting": "Para: Rozmrażanie",
+          "cooking_oven_program_steammodes_doughproving": "Para: Wyrastanie ciasta",
+          "cooking_oven_program_steammodes_reheat": "Para: Podgrzewanie",
+          "cooking_oven_program_steammodes_sousvide": "Para: Sous Vide",
+          "cooking_oven_program_steammodes_steam": "Para",
+          "cooking_oven_program_subsequentmode_continuecooking": "Następny tryb: Kontynuuj gotowanie",
+          "cooking_oven_program_subsequentmode_drying": "Następny tryb: Suszenie",
+          "cooking_oven_program_subsequentmode_keepwarm": "Następny tryb: Podtrzymanie ciepła",
+          "cooking_oven_program_subsequentmode_leavetorest": "Następny tryb: Zostaw do odpoczynku",
+          "cooking_oven_program_subsequentmode_startbaking": "Następny tryb: Rozpocznij pieczenie",
+          "cooking_common_program_hood_automatic": "Automatyczny",
+          "cooking_common_program_hood_delayedshutoff": "Wyłączenie z opóźnieniem",
+          "cooking_common_program_hood_venting": "Wentylacja",
+          "laundrycare_washer_program_automatic30_auto30_auto30": "Pranie – automatyczne delikatne/30",
+          "laundrycare_washer_program_auto60": "Pranie – automatyczne 60",
+          "laundrycare_washer_program_automatic4060_auto40_auto40": "Pranie – automatyczne 40-60",
+          "laundrycare_washer_program_cotton_cotton_cotton": "Pranie – bawełna",
+          "laundrycare_washer_program_cotton": "Pranie – bawełna",
+          "laundrycare_washer_program_darkwash_darkwash_darkwash": "Pranie – ciemne",
+          "laundrycare_washer_program_darkwash_curtains_curtains": "Pranie – zasłony",
+          "laundrycare_washer_program_delicatessilk_delicatessilk_delicatessilk": "Pranie – delikatne/jedwab",
+          "laundrycare_washer_program_delicatessilk_delicatessilk_delicatessilkmp": "Pranie – Ochrona przed mikroplastikiem",
+          "laundrycare_washer_program_downduvet_down_down": "Pranie – puch",
+          "laundrycare_washer_program_drumclean_drumclean_drumclean": "Czyszczenie bębna (stare)",
+          "laundrycare_washer_program_drumclean_drumclean70_drumclean70": "Czyszczenie bębna",
+          "laundrycare_washer_program_easycare_easycare_easycare": "Pranie – łatwa pielęgnacja",
+          "laundrycare_washer_program_labeleu19_labeleu19_eco4060": "Pranie – eco 40-60",
+          "laundrycare_washer_program_mix_mix_mix": "Mix szybki",
+          "laundrycare_washer_program_outdoor_outdoor_outdoor": "Pranie – outdoor",
+          "laundrycare_washer_program_powerspeed59_powerspeed59_powerspeed59": "PowerSpeed 59'",
+          "laundrycare_washer_program_rinse_rinse_rinse": "Płukanie",
+          "laundrycare_washer_program_sensitive_sensitive_sensitive": "Pranie – sensitive",
+          "laundrycare_washer_program_shirtsblouses_shirtsblouses_shirtsblouses": "Pranie – koszule/bluzki",
+          "laundrycare_washer_program_shirtsblouses_sportfitness_sportfitness": "Pranie – odzież sportowa",
+          "laundrycare_washer_program_spin_spin_spindrain": "Wirowanie/odpływ",
+          "laundrycare_washer_program_steaming_steaming_steaming": "Para/Ułatwienie prasowania",
+          "laundrycare_washer_program_super153045_super1530_super1530": "Pranie – super krótki 15 min/30 min",
+          "laundrycare_washer_program_towels_towels_towels": "Ręczniki",
+          "laundrycare_washer_program_wool_wool_wool": "Pranie – wełna",
+          "laundrycare_washer_program_sportfitness": "Pranie – odzież sportowa",
+          "laundrycare_common_program_juststart": "Just start",
+          "laundrycare_dryer_program_blankets": "Suszenie – odzież puchowa",
+          "laundrycare_dryer_program_businessshirts": "Koszule",
+          "laundrycare_dryer_program_cotton": "Suszenie – bawełna",
+          "laundrycare_dryer_program_dessous": "Suszenie – bielizna",
+          "laundrycare_dryer_program_hygiene": "Suszenie – higieniczne",
+          "laundrycare_dryer_program_inbasket": "Suszenie – wełna w koszyku",
+          "laundrycare_dryer_program_mix": "Suszenie – mieszane",
+          "laundrycare_dryer_program_outdoor": "Suszenie – outdoor",
+          "laundrycare_dryer_program_pillow": "Suszenie – kołdra",
+          "laundrycare_dryer_program_super40": "Suszenie – ekspresowe 40 min",
+          "laundrycare_dryer_program_synthetic": "Suszenie – łatwa pielęgnacja",
+          "laundrycare_dryer_program_timecold": "Program czasowy – zimne",
+          "laundrycare_dryer_program_timewarm": "Program czasowy – ciepłe",
+          "laundrycare_dryer_program_towels": "Suszenie – ręczniki",
+          "laundrycare_dryer_program_shirtsblouses_sportfitness": "Suszenie – odzież sportowa",
+          "laundrycare_washerdryer_program_towels_towels": "Pranie i suszenie – ręczniki",
+          "laundrycare_washerdryer_program_cotton_cotton": "Pranie i suszenie – bawełna",
+          "laundrycare_washerdryer_program_mix_mix": "Pranie i suszenie – mieszane",
+          "laundrycare_washerdryer_program_wool_wool": "Pranie i suszenie – wełna",
+          "laundrycare_washerdryer_program_sportfitness_sportfitness": "Pranie i suszenie – odzież sportowa",
+          "laundrycare_washerdryer_program_washanddry_60": "Pranie i suszenie – 60'",
+          "laundrycare_washerdryer_program_downduvet_down": "Pranie i suszenie – puch",
+          "laundrycare_washerdryer_program_labeleu19_labeleu19_eco4060": "Pranie i suszenie – eco 40-60",
+          "laundrycare_washerdryer_program_cotton_cotton_cotton": "Pranie i suszenie – bawełna",
+          "laundrycare_washerdryer_program_mix_hhmix_hhmix": "Pranie i suszenie – szybkie mieszane",
+          "laundrycare_washerdryer_program_easycare_hhsynthetics_hhsynthetics": "Pranie i suszenie – łatwe w pielęgnacji",
+          "laundrycare_washerdryer_program_delicatessilk_delicatessilk_delicatessilk": "Pranie i suszenie – delikatne/jedwab",
+          "laundrycare_washerdryer_program_wool_wool_wool": "Pranie i suszenie – wełna",
+          "laundrycare_washerdryer_program_spin_spin_spindrain": "Wirowanie/odpływ",
+          "laundrycare_washerdryer_program_rinse_rinse_rinse": "Płukanie",
+          "laundrycare_washerdryer_program_sportfitness_sportfitness_sportfitness": "Pranie i suszenie – odzież sportowa",
+          "laundrycare_washerdryer_program_automatic4060_auto40_auto40": "Pranie i suszenie – automatyczne 40°C",
+          "laundrycare_washer_program_cotton_colour": "Bawełna kolorowa",
+          "laundrycare_washer_program_cotton_eco4060": "Bawełna eco 40-60",
+          "laundrycare_washer_program_delicatessilk": "Delikatne/jedwab",
+          "laundrycare_washer_program_downduvet_duvet": "Puch/kołdra",
+          "laundrycare_washer_program_easycare": "Łatwa pielęgnacja",
+          "laundrycare_washer_program_mix": "Mieszane",
+          "laundrycare_washer_program_rinse": "Płukanie",
+          "laundrycare_washer_program_sensitive": "Sensitive",
+          "laundrycare_washer_program_spin_spindrain": "Wirowanie/odpływ",
+          "laundrycare_washer_program_super153045_super1530": "Super 15/30",
+          "laundrycare_washer_program_wool": "Wełna",
+          "laundrycare_washer_program_easycare_antistainlight_blood": "Łatwa pielęgnacja – AntiStain (krew)",
+          "laundrycare_washer_program_easycare_antistainlight_butteroil": "Łatwa pielęgnacja – AntiStain (masło/olej)",
+          "laundrycare_washer_program_easycare_antistainlight_cosmetics": "Łatwa pielęgnacja – AntiStain (kosmetyki)",
+          "laundrycare_washer_program_easycare_antistainlight_tea": "Łatwa pielęgnacja – AntiStain (herbata)",
+          "consumerproducts_coffeemaker_program_beverage_caffegrande": "Caffè Grande",
+          "consumerproducts_coffeemaker_program_beverage_caffelatte": "Caffè Latte",
+          "consumerproducts_coffeemaker_program_beverage_cappuccino": "Cappuccino",
+          "consumerproducts_coffeemaker_program_beverage_coffee": "Kawa",
+          "consumerproducts_coffeemaker_program_beverage_espresso": "Espresso",
+          "consumerproducts_coffeemaker_program_beverage_espressodoppio": "Espresso Doppio",
+          "consumerproducts_coffeemaker_program_beverage_espressomacchiato": "Espresso Macchiato",
+          "consumerproducts_coffeemaker_program_beverage_hotwater": "Gorąca woda",
+          "consumerproducts_coffeemaker_program_beverage_lattemacchiato": "Latte Macchiato",
+          "consumerproducts_coffeemaker_program_beverage_milkfroth": "Spienione mleko",
+          "consumerproducts_coffeemaker_program_beverage_ristretto": "Ristretto",
+          "consumerproducts_coffeemaker_program_beverage_warmmilk": "Ciepłe mleko",
+          "consumerproducts_coffeemaker_program_beverage_xlcoffee": "Kawa XL",
+          "consumerproducts_coffeemaker_program_coffeeworld_americano": "Americano",
+          "consumerproducts_coffeemaker_program_coffeeworld_blackeye": "Blackeye",
+          "consumerproducts_coffeemaker_program_coffeeworld_cafeaulait": "Café au Lait",
+          "consumerproducts_coffeemaker_program_coffeeworld_cafeconleche": "Café Conleche",
+          "consumerproducts_coffeemaker_program_coffeeworld_cafecortado": "Café Cortado",
+          "consumerproducts_coffeemaker_program_coffeeworld_coldbrew": "Cold Brew",
+          "consumerproducts_coffeemaker_program_coffeeworld_coldbrewmacchiato": "Cold Brew Macchiato",
+          "consumerproducts_coffeemaker_program_coffeeworld_cortado": "Cortado",
+          "consumerproducts_coffeemaker_program_coffeeworld_deadeye": "Deadeye",
+          "consumerproducts_coffeemaker_program_coffeeworld_doppio": "Doppio",
+          "consumerproducts_coffeemaker_program_coffeeworld_flatwhite": "Flat White",
+          "consumerproducts_coffeemaker_program_coffeeworld_galao": "Galão",
+          "consumerproducts_coffeemaker_program_coffeeworld_garoto": "Garoto",
+          "consumerproducts_coffeemaker_program_coffeeworld_grosserbrauner": "Großer Brauner",
+          "consumerproducts_coffeemaker_program_coffeeworld_kaapi": "Kaapi",
+          "consumerproducts_coffeemaker_program_coffeeworld_kleinerbrauner": "Kleiner Brauner",
+          "consumerproducts_coffeemaker_program_coffeeworld_koffieverkeerd": "Koffie Verkeerd",
+          "consumerproducts_coffeemaker_program_coffeeworld_redeye": "Redeye",
+          "consumerproducts_coffeemaker_program_coffeeworld_slowbrew": "Slow Brew",
+          "consumerproducts_coffeemaker_program_coffeeworld_verlaengerter": "Verlängerter",
+          "consumerproducts_coffeemaker_program_coffeeworld_verlaengerterbraun": "Verlängerter Braun",
+          "consumerproducts_coffeemaker_program_coffeeworld_wienermelange": "Wiener Melange",
+          "consumerproducts_coffeemaker_program_cleaningmodes_applianceoffrinsing": "Płukanie przy wyłączaniu",
+          "consumerproducts_coffeemaker_program_cleaningmodes_applianceonrinsing": "Płukanie przy włączaniu",
+          "consumerproducts_coffeemaker_program_cleaningmodes_calcnclean": "Calc'n'Clean",
+          "consumerproducts_coffeemaker_program_cleaningmodes_clean": "Czyszczenie",
+          "consumerproducts_coffeemaker_program_cleaningmodes_cleanbrewingunitmanually": "Czyszczenie jednostki zaparzającej",
+          "consumerproducts_coffeemaker_program_cleaningmodes_cleanbrewingunitmanuallydetailed": "Czyszczenie jednostki zaparzającej (szczegółowe)",
+          "consumerproducts_coffeemaker_program_cleaningmodes_cleanoutletmanually": "Czyszczenie dyszy napojów",
+          "consumerproducts_coffeemaker_program_cleaningmodes_descale": "Odkamienianie",
+          "consumerproducts_coffeemaker_program_cleaningmodes_frostprotection": "Ochrona przed mrozem",
+          "consumerproducts_coffeemaker_program_cleaningmodes_removewaterfilter": "Wyjmowanie filtra wody",
+          "consumerproducts_coffeemaker_program_cleaningmodes_replacewaterfilter": "Wymiana filtra wody",
+          "consumerproducts_coffeemaker_program_cleaningmodes_rinsemilksystem": "Płukanie systemu mleka",
+          "consumerproducts_coffeemaker_program_cleaningmodes_rinsewaterfilter": "Płukanie filtra wody",
+          "consumerproducts_coffeemaker_program_cleaningmodes_specialrinsing": "Specjalne płukanie",
+          "laundrycare_common_program_memory1": "Pamięć 1",
+          "laundrycare_common_program_memory2": "Pamięć 2",
+          "laundrycare_common_program_memory3": "Pamięć 3",
+          "laundrycare_common_program_memory4": "Pamięć 4",
+          "laundrycare_common_program_memory5": "Pamięć 5",
+          "laundrycare_common_program_memory6": "Pamięć 6",
+          "laundrycare_common_program_memory7": "Pamięć 7",
+          "laundrycare_common_program_memory8": "Pamięć 8",
+          "cooking_hob_program_dish_fryingsensor_creamsauce": "Czujnik smażenia: Sos śmietanowy",
+          "cooking_hob_program_dish_fryingsensor_dumplings": "Czujnik smażenia: Pierogi/Kluski",
+          "cooking_hob_program_dish_fryingsensor_fondue": "Czujnik smażenia: Fondue",
+          "cooking_hob_program_dish_fryingsensor_meltingbutter": "Czujnik smażenia: Roztapianie masła",
+          "cooking_hob_program_dish_fryingsensor_meltingcheese": "Czujnik smażenia: Roztapianie sera",
+          "cooking_hob_program_dish_fryingsensor_meltingchocolate": "Czujnik smażenia: Roztapianie czekolady",
+          "cooking_hob_program_dish_fryingsensor_mussels": "Czujnik smażenia: Małże",
+          "cooking_hob_program_dish_fryingsensor_onionrings": "Czujnik smażenia: Krążki cebuli",
+          "cooking_hob_program_dish_fryingsensor_ribeyemedium": "Czujnik smażenia: Ribeye (średni)",
+          "cooking_hob_program_dish_fryingsensor_ribeyerare": "Czujnik smażenia: Ribeye (krwisty)",
+          "cooking_hob_program_dish_fryingsensor_sardines": "Czujnik smażenia: Sardynki",
+          "cooking_hob_program_dish_fryingsensor_skewers": "Czujnik smażenia: Szaszłyki",
+          "cooking_hob_program_dish_fryingsensor_squid": "Czujnik smażenia: Kalmary",
+          "cooking_hob_program_dish_fryingsensor_tempuravegetables": "Czujnik smażenia: Warzywa w tempurze",
+          "cooking_hob_program_dish_fryingsensor_toastingbread": "Czujnik smażenia: Tostowanie chleba",
+          "favorite_011": "Ulubiony 11",
+          "favorite_012": "Ulubiony 12",
+          "favorite_013": "Ulubiony 13",
+          "favorite_014": "Ulubiony 14",
+          "favorite_015": "Ulubiony 15",
+          "favorite_016": "Ulubiony 16",
+          "favorite_017": "Ulubiony 17",
+          "favorite_018": "Ulubiony 18",
+          "favorite_019": "Ulubiony 19",
+          "favorite_020": "Ulubiony 20",
+          "favorite_021": "Ulubiony 21",
+          "favorite_022": "Ulubiony 22",
+          "favorite_023": "Ulubiony 23",
+          "favorite_024": "Ulubiony 24",
+          "favorite_025": "Ulubiony 25",
+          "favorite_026": "Ulubiony 26",
+          "favorite_027": "Ulubiony 27",
+          "favorite_028": "Ulubiony 28",
+          "favorite_029": "Ulubiony 29",
+          "favorite_030": "Ulubiony 30"
+        }
+      },
+      "sensor_rinse_aid": {
+        "name": "Nabłyszczacz",
+        "state": {
+          "empty": "pusty",
+          "nearly_empty": "prawie pusty",
+          "full": "pełny"
+        }
+      },
+      "sensor_salt": {
+        "name": "Sól",
+        "state": {
+          "empty": "pusta",
+          "nearly_empty": "prawie pusta",
+          "full": "pełna"
+        }
+      },
+      "sensor_water_tank": {
+        "name": "Zbiornik wody",
+        "state": {
+          "empty": "pusty",
+          "nearly_empty": "prawie pusty",
+          "not_inserted": "nie włożony",
+          "full": "pełny"
+        }
+      },
+      "sensor_drip_tray": {
+        "name": "Tacka ociekowa",
+        "state": {
+          "ok": "ok",
+          "not_inserted": "nie włożona",
+          "full": "pełna"
+        }
+      },
+      "sensor_start_in": {
+        "name": "Uruchomienie za"
+      },
+      "sensor_finish_in": {
+        "name": "Zakończenie za"
+      },
+      "sensor_count_started": {
+        "name": "Liczba uruchomień"
+      },
+      "sensor_end_trigger": {
+        "name": "Warunek zakończenia programu",
+        "state": {
+          "programfinished": "zakończony",
+          "programabortedbyuser": "przerwany przez użytkownika",
+          "programabortedbyappliance": "przerwany przez urządzenie",
+          "programabortedbyappliancecriticalerror": "krytyczny błąd"
+        }
+      },
+      "sensor_interval_time_off": {
+        "name": "Interwał wyłączenia"
+      },
+      "sensor_interval_time_on": {
+        "name": "Interwał włączenia"
+      },
+      "sensor_delayed_shutoff_time": {
+        "name": "Opóźnione wyłączenie"
+      },
+      "sensor_power_state": {
+        "name": "Stan zasilania",
+        "state": {
+          "mainsoff": "sieć wyłączona",
+          "off": "wyłączony",
+          "on": "włączony",
+          "standby": "czuwanie"
+        }
+      },
+      "sensor_door_state": {
+        "name": "Drzwi",
+        "state": {
+          "open": "otwarte",
+          "closed": "zamknięte",
+          "locked": "zablokowane",
+          "ajar": "uchylone"
+        }
+      },
+      "sensor_laundry_reload": {
+        "name": "Dołożenie prania",
+        "state": {
+          "impossible": "niemożliwe",
+          "possiblepauseprogram": "możliwe – wstrzymaj program",
+          "possibleopendoor": "możliwe – otwórz drzwi"
+        }
+      },
+      "sensor_laundry_process_phase": {
+        "name": "Faza procesu",
+        "state": {
+          "nophase": "brak fazy",
+          "prewash": "pranie wstępne",
+          "intermediatespin": "wirowanie pośrednie",
+          "fillingdetergent": "nabieranie detergentu",
+          "detectingload": "wykrywanie wsadu",
+          "heating": "nagrzewanie",
+          "washing": "pranie",
+          "cooldown": "stygnięcie",
+          "rinsingfoam": "płukanie piany",
+          "rinsing": "płukanie",
+          "rinsingaquasensor": "płukanie z czujnikiem wody",
+          "rinseonly": "samo płukanie",
+          "waterproofing": "impregnacja",
+          "rinsingsoftener": "płukanie z płynem do płukania",
+          "holdafterrinse": "podtrzymanie po płukaniu",
+          "pumping": "pompowanie",
+          "spinningfinal": "końcowe wirowanie",
+          "lessironing": "łatwe prasowanie",
+          "fluffing": "napowietrzanie",
+          "soaking": "moczenie",
+          "hygienicsteamfogging": "higieniczne parowanie",
+          "guardingoxy": "ochrona tlenem",
+          "generatingozone": "generowanie ozonu",
+          "degradingozone": "rozkład ozonu",
+          "drying": "suszenie",
+          "coolingdown": "chłodzenie",
+          "additionalcoolingdown": "dodatkowe chłodzenie",
+          "guardingwrinkle": "ochrona przed gnieceniem",
+          "detectingtextile": "wykrywanie tkaniny",
+          "detectingsoil": "wykrywanie zabrudzenia",
+          "disinfecting": "dezynfekcja",
+          "lowtemperaturehygiene": "higiena w niskiej temperaturze",
+          "steamingactive": "aktywne parowanie",
+          "irondryreached": "osiągnięto suchość do prasowania",
+          "cupboarddryreached": "osiągnięto suchość szafkową",
+          "cupboarddryplusreached": "osiągnięto suchość szafkową plus",
+          "cleaningheatexchanger": "czyszczenie wymiennika ciepła",
+          "slightlydampreached": "osiągnięto lekką wilgotność",
+          "extradryreached": "osiągnięto extra suchość",
+          "gentlydryreached": "osiągnięto delikatną suchość",
+          "quickcare": "szybka pielęgnacja",
+          "depthcarephase1": "głęboka pielęgnacja faza 1",
+          "depthcarephase2": "głęboka pielęgnacja faza 2",
+          "coldrefreshing": "zimne odświeżanie",
+          "steaming": "parowanie",
+          "foam": "piana",
+          "testprogramdummytextfinalspeedreached": "testowy program – osiągnięto końcową prędkość",
+          "rinsingfoamf21": "płukanie piany F21",
+          "handsoak": "moczenie ręczne",
+          "vacant": "wolny",
+          "spinning": "wirowanie",
+          "displayspinabortnospin": "anulowanie wirowania – brak wirowania",
+          "multiplesoak": "wielokrotne moczenie",
+          "laundryrefreshing": "odświeżanie prania",
+          "reload": "dołożenie prania",
+          "hotmoistheatingwetting": "gorące parowe nagrzewanie – zwilżanie",
+          "hotmoistheatingheating": "gorące parowe nagrzewanie – nagrzewanie",
+          "hotmoistheatingwashing": "gorące parowe nagrzewanie – pranie",
+          "moistureremoval": "usuwanie wilgoci",
+          "selfcleaning": "samoczyszczenie",
+          "hygiene": "higiena",
+          "smartsoak": "inteligentne moczenie",
+          "soakpause": "przerwa moczenia",
+          "soakfinished": "moczenie zakończone",
+          "anyphase": "dowolna faza"
+        }
+      },
+      "sensor_count_completed": {
+        "name": "Liczba zakończonych"
+      },
+      "sensor_flex_start": {
+        "name": "Elastyczny start",
+        "state": {
+          "disabled": "wyłączony",
+          "enabled": "włączony",
+          "pending": "oczekujący",
+          "scheduled": "zaplanowany",
+          "started": "uruchomiony",
+          "finished": "zakończony"
+        }
+      },
+      "sensor_dryer_process_phase": {
+        "name": "Faza procesu",
+        "state": {
+          "steamactive": "aktywne parowanie",
+          "progstarted": "program uruchomiony",
+          "drying": "suszenie",
+          "irondryreached": "osiągnięto suchość do prasowania",
+          "cupboarddryreached": "osiągnięto suchość szafkową",
+          "cubboarddryplusreached": "osiągnięto suchość szafkową plus",
+          "cooling": "chłodzenie",
+          "finishedanticrease": "zakończono ochronę przed gnieceniem",
+          "heatexchangercleaning": "czyszczenie wymiennika ciepła",
+          "slightlydampreached": "osiągnięto lekką wilgotność",
+          "extradryreached": "osiągnięto extra suchość",
+          "quickcare": "szybka pielęgnacja",
+          "depthcarephase1": "głęboka pielęgnacja faza 1",
+          "depthcarephase2": "głęboka pielęgnacja faza 2",
+          "spare": "zapasowy"
+        }
+      },
+      "sensor_temperature_ambient": {
+        "name": "Temperatura otoczenia"
+      },
+      "sensor_laundry_load_recommendation": {
+        "name": "Zalecenie dotyczące wsadu"
+      },
+      "sensor_temperature_memory_freezer": {
+        "name": "Temperatura pamięci zamrażarki"
+      },
+      "sensor_laundry_spin_speed": {
+        "name": "Prędkość wirowania",
+        "state": {
+          "off": "wyłączone",
+          "rpm400": "400 obr./min",
+          "rpm600": "600 obr./min",
+          "rpm700": "700 obr./min",
+          "rpm800": "800 obr./min",
+          "rpm900": "900 obr./min",
+          "rpm1000": "1000 obr./min",
+          "rpm1200": "1200 obr./min",
+          "rpm1400": "1400 obr./min",
+          "rpm1500": "1500 obr./min",
+          "rpm1600": "1600 obr./min",
+          "rinsehold": "podtrzymanie płukania",
+          "auto": "auto"
+        }
+      },
+      "sensor_estimated_remaining_program_time": {
+        "name": "Szacowany całkowity czas programu"
+      },
+      "sensor_oven_water_tank": {
+        "name": "Zbiornik wody{group_name}",
+        "state": {
+          "ok": "ok",
+          "empty": "pusty",
+          "unplugged": "niepodłączony"
+        }
+      },
+      "sensor_oven_current_temperature": {
+        "name": "Bieżąca temperatura{group_name}"
+      },
+      "sensor_oven_current_meatprobe_temperature": {
+        "name": "Bieżąca temperatura sondy mięsnej"
+      },
+      "sensor_heatup_progress": {
+        "name": "Postęp nagrzewania"
+      },
+      "sensor_wifi_signal_strength": {
+        "name": "Siła sygnału WiFi"
+      },
+      "sensor_grease_filter_saturation": {
+        "name": "Nasycenie filtra tłuszczu"
+      },
+      "sensor_carbon_filter_saturation": {
+        "name": "Nasycenie filtra węglowego"
+      },
+      "sensor_hob_zone_state": {
+        "name": "Stan strefy {group_name}",
+        "state": {
+          "notselectable": "niedostępna",
+          "off": "wyłączona",
+          "active": "aktywna",
+          "residuelheat": "ciepło resztkowe"
+        }
+      },
+      "sensor_hob_zone_operationstate": {
+        "name": "Stan operacyjny strefy {group_name}",
+        "state": {
+          "inactive": "bezczynny",
+          "ready": "gotowy",
+          "delayedstart": "opóźniony start",
+          "run": "uruchomiony",
+          "pause": "wstrzymany",
+          "actionrequired": "wymagane działanie",
+          "finished": "zakończony",
+          "error": "błąd",
+          "aborting": "przerywanie"
+        }
+      },
+      "sensor_hob_zone_power_level": {
+        "name": "Poziom mocy strefy {group_name}",
+        "state": {
+          "off": "wyłączony",
+          "keepwarm": "utrzymywanie ciepła",
+          "10": "10",
+          "15": "15",
+          "20": "20",
+          "25": "25",
+          "30": "30",
+          "35": "35",
+          "40": "40",
+          "45": "45",
+          "50": "50",
+          "55": "55",
+          "60": "60",
+          "65": "65",
+          "70": "70",
+          "75": "75",
+          "80": "80",
+          "85": "85",
+          "90": "90",
+          "boost1": "Boost 1",
+          "boost2": "Boost 2"
+        }
+      },
+      "sensor_hob_zone_frying_sensor_level": {
+        "name": "Poziom czujnika smażenia strefy {group_name}",
+        "state": {
+          "off": "wyłączony",
+          "70dc": "70 °C",
+          "80dc": "80 °C",
+          "90dc": "90 °C",
+          "100dc": "100 °C",
+          "110dc": "110 °C",
+          "120dc": "120 °C",
+          "140dc": "140 °C",
+          "160dc": "160 °C",
+          "180dc": "180 °C",
+          "200dc": "200 °C",
+          "220dc": "220 °C"
+        }
+      },
+      "sensor_hob_zone_current_temperature": {
+        "name": "Bieżąca temperatura strefy {group_name}"
+      },
+      "sensor_hob_zone_heatup_progress": {
+        "name": "Postęp nagrzewania strefy {group_name}"
+      },
+      "sensor_hob_zone_duration": {
+        "name": "Czas trwania strefy {group_name}"
+      },
+      "sensor_hob_zone_elapsed_program_time": {
+        "name": "Miniony czas programu strefy {group_name}"
+      },
+      "sensor_hob_zone_remaining_program_time": {
+        "name": "Pozostały czas programu strefy {group_name}"
+      },
+      "sensor_hob_zone_program_progress": {
+        "name": "Postęp programu strefy {group_name}"
+      },
+      "sensor_count_ristretto_espresso": {
+        "name": "Liczba Ristretto/Espresso"
+      },
+      "sensor_count_coffee": {
+        "name": "Liczba kaw"
+      },
+      "sensor_count_coffee_milk": {
+        "name": "Liczba kaw z mlekiem"
+      },
+      "sensor_count_frothy_milk": {
+        "name": "Liczba pianek mlecznych"
+      },
+      "sensor_count_hot_milk": {
+        "name": "Liczba gorącego mleka"
+      },
+      "sensor_count_hot_water": {
+        "name": "Liczba gorącej wody"
+      },
+      "sensor_count_hot_water_cups": {
+        "name": "Liczba filiżanek gorącej wody"
+      },
+      "sensor_count_powder_coffee": {
+        "name": "Liczba kaw z proszku"
+      },
+      "sensor_countdown_calc_n_clean": {
+        "name": "Wymagane Calc'n'Clean"
+      },
+      "sensor_countdown_cleaning": {
+        "name": "Wymagane czyszczenie"
+      },
+      "sensor_countdown_descaling": {
+        "name": "Wymagane odkamienianie"
+      },
+      "sensor_countdown_water_filter": {
+        "name": "Wymiana filtra wody"
+      },
+      "sensor_coffeemaker_process_phase": {
+        "name": "Faza procesu",
+        "state": {
+          "none": "bezczynny",
+          "beverageaborting": "anulowanie napoju",
+          "grinding": "mielenie ziaren",
+          "brewingunitmovesup": "przygotowywanie jednostki parzenia",
+          "coffeebrewing": "parzenie kawy",
+          "brewingunitmovesdown": "kończenie parzenia",
+          "milkfroth": "spienianie mleka",
+          "cleaningmilksystem": "czyszczenie systemu mleka",
+          "hotwaterdispensing": "dozowanie gorącej wody",
+          "cleaningmode": "tryb czyszczenia",
+          "descalephase": "odkamienianie",
+          "rinsephase": "płukanie",
+          "cleanphase": "czyszczenie",
+          "warmmilk": "podgrzewanie mleka",
+          "frostprotection": "aktywna ochrona przed mrozem",
+          "specialrinsing": "specjalne płukanie",
+          "waterfilteractivation": "aktywacja filtra wody",
+          "lattemacpause": "przerwa Latte Macchiato",
+          "startphase": "uruchamianie",
+          "skipphase": "pomijanie kroku",
+          "preliminary": "krok wstępny",
+          "autodescalephase": "automatyczne odkamienianie",
+          "autocleanphase": "automatyczne czyszczenie",
+          "drainingdescalephase": "odprowadzanie po odkamienianiu",
+          "milkdescalephase": "odkamienianie systemu mleka",
+          "coldbrew": "parzenie Cold Brew",
+          "dripbrew": "parzenie przelewowe",
+          "emptypowdersources": "opróżnianie źródeł proszku",
+          "roundrobinflush": "płukanie systemu",
+          "initializenewcartridge": "inicjalizacja wkładu"
+        }
+      },
+      "sensor_laundry_status_idos1_fill_level": {
+        "name": "Poziom napełnienia i-DOS 1",
+        "state": {
+          "poor": "niski",
+          "filled": "napełniony"
+        }
+      },
+      "sensor_laundry_status_idos2_fill_level": {
+        "name": "Poziom napełnienia i-DOS 2",
+        "state": {
+          "poor": "niski",
+          "filled": "napełniony"
+        }
+      }
+    },
+    "select": {
+      "select_time_format": {
+        "name": "Format czasu",
+        "state": {
+          "24hours": "24 godziny",
+          "12hours": "12 godzin"
+        }
+      },
+      "select_oven_clock_display": {
+        "name": "Wyświetlacz zegara",
+        "state": {
+          "clock01": "cyfrowy",
+          "clock02": "analogowy"
+        }
+      },
+      "select_dishwasher_auto_power_off": {
+        "name": "Auto wyłączenie",
+        "state": {
+          "off": "wyłączone",
+          "oneminute": "Po 1 minucie",
+          "120minutes": "Po 2 godzinach"
+        }
+      },
+      "select_drying_assistant_all_programs": {
+        "name": "Asystent suszenia – wszystkie programy",
+        "state": {
+          "off": "wyłączone",
+          "allprograms": "wszystkie programy",
+          "ecoasdefault": "eco 50"
+        }
+      },
+      "select_hot_water": {
+        "name": "Podłączenie wody",
+        "state": {
+          "coldwater": "zimna woda",
+          "hotwater": "ciepła woda"
+        }
+      },
+      "select_rinse_aid": {
+        "name": "Nabłyszczacz",
+        "state": {
+          "off": "poziom 0 (wyłączone)",
+          "r01": "poziom 1 (najniższy)",
+          "r02": "poziom 2 (niski)",
+          "r03": "poziom 3 (średni)",
+          "r04": "poziom 4 (śr./wysoki)",
+          "r05": "poziom 5 (wysoki)",
+          "r06": "poziom 6 (najwyższy)"
+        }
+      },
+      "select_sound_level_signal": {
+        "name": "Poziom głośności sygnału",
+        "state": {
+          "high": "wysoki",
+          "low": "niski",
+          "medium": "średni",
+          "off": "wyłączone"
+        }
+      },
+      "select_sound_level_key": {
+        "name": "Poziom głośności klawiszy",
+        "state": {
+          "off": "wyłączone",
+          "low": "niski",
+          "medium": "średni",
+          "high": "wysoki"
+        }
+      },
+      "select_flexspray_type": {
+        "name": "Typ PowerControl",
+        "state": {
+          "front": "przód",
+          "back": "tył",
+          "custom": "własne",
+          "individual": "indywidualne"
+        }
+      },
+      "select_flexspray_front_left": {
+        "name": "PowerControl – przód lewy",
+        "state": {
+          "delicate": "delikatne",
+          "normal": "normalne",
+          "heavy": "intensywne"
+        }
+      },
+      "select_flexspray_back_left": {
+        "name": "PowerControl – tył lewy",
+        "state": {
+          "delicate": "delikatne",
+          "normal": "normalne",
+          "heavy": "intensywne"
+        }
+      },
+      "select_flexspray_back_right": {
+        "name": "PowerControl – tył prawy",
+        "state": {
+          "delicate": "delikatne",
+          "normal": "normalne",
+          "heavy": "intensywne"
+        }
+      },
+      "select_flexspray_front_right": {
+        "name": "PowerControl – przód prawy",
+        "state": {
+          "delicate": "delikatne",
+          "normal": "normalne",
+          "heavy": "intensywne"
+        }
+      },
+      "select_flexspray_custom_front_left": {
+        "name": "PowerControl własne – przód lewy",
+        "state": {
+          "delicate": "delikatne",
+          "normal": "normalne",
+          "heavy": "intensywne"
+        }
+      },
+      "select_flexspray_custom_back_left": {
+        "name": "PowerControl własne – tył lewy",
+        "state": {
+          "delicate": "delikatne",
+          "normal": "normalne",
+          "heavy": "intensywne"
+        }
+      },
+      "select_flexspray_custom_back_right": {
+        "name": "PowerControl własne – tył prawy",
+        "state": {
+          "delicate": "delikatne",
+          "normal": "normalne",
+          "heavy": "intensywne"
+        }
+      },
+      "select_flexspray_custom_front_right": {
+        "name": "PowerControl własne – przód prawy",
+        "state": {
+          "delicate": "delikatne",
+          "normal": "normalne",
+          "heavy": "intensywne"
+        }
+      },
+      "select_water_hardness": {
+        "name": "Twardość wody",
+        "state": {
+          "h00": "°E 0-8 miękka (0-1.1 mmol/l)",
+          "h01": "°E 9-10 miękka (1.2-1.4 mmol/l)",
+          "h02": "°E 11-12 średnia (1.5-1.8 mmol/l)",
+          "h03": "°E 13-15 średnia (1.9-2.1 mmol/l)",
+          "h04": "°E 16-20 średnia (2.2-2.9 mmol/l)",
+          "h05": "°E 21-26 twarda (3.0-3.7 mmol/l)",
+          "h06": "°E 27-38 twarda (3.8-5.4 mmol/l)",
+          "h07": "°E 39-62 twarda (5.5-8.9 mmol/l)"
+        }
+      },
+      "select_remote_control_level": {
+        "name": "Zdalne sterowanie",
+        "state": {
+          "monitoring": "wyłączone",
+          "manualremotestart": "ręczny zdalny start",
+          "permanentremotestart": "stały zdalny start"
+        }
+      },
+      "select_program": {
+        "name": "Wybrany program",
+        "state": {
+          "dishcare_dishwasher_program_intensiv70": "Intensiv 70",
+          "dishcare_dishwasher_program_auto2": "Auto 2",
+          "dishcare_dishwasher_program_eco50": "Eco 50",
+          "dishcare_dishwasher_program_quick45": "Quick 45",
+          "dishcare_dishwasher_program_prerinse": "PreRinse",
+          "dishcare_dishwasher_program_quick65": "Quick 65",
+          "dishcare_dishwasher_program_machinecare": "MachineCare",
+          "dishcare_dishwasher_program_nightwash": "NightWash",
+          "dishcare_dishwasher_program_glas40": "Glass 40",
+          "dishcare_dishwasher_program_glassshine": "Brilliant Shine",
+          "dishcare_dishwasher_program_kurz60": "Speed 60",
+          "dishcare_dishwasher_program_learningdishwasher": "Inteligentny",
+          "favorite_001": "Ulubiony 1",
+          "favorite_002": "Ulubiony 2",
+          "favorite_003": "Ulubiony 3",
+          "favorite_004": "Ulubiony 4",
+          "favorite_005": "Ulubiony 5",
+          "favorite_006": "Ulubiony 6",
+          "favorite_007": "Ulubiony 7",
+          "favorite_008": "Ulubiony 8",
+          "favorite_009": "Ulubiony 9",
+          "favorite_010": "Ulubiony 10",
+          "cooking_hob_program_cookingsensor": "Czujnik gotowania",
+          "cooking_hob_program_dish_cookingsensor_beansinpressurecooker": "Czujnik gotowania: Fasola w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_beefinpressurecooker": "Czujnik gotowania: Wołowina w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_boiledeggs": "Czujnik gotowania: Jajka na twardo",
+          "cooking_hob_program_dish_cookingsensor_boilingbeef": "Czujnik gotowania: Gotowanie wołowiny",
+          "cooking_hob_program_dish_cookingsensor_boilingbroccoli": "Czujnik gotowania: Gotowanie brokułów",
+          "cooking_hob_program_dish_cookingsensor_boilingbrusselssprout": "Czujnik gotowania: Gotowanie brukselki",
+          "cooking_hob_program_dish_cookingsensor_boilingcauliflower": "Czujnik gotowania: Gotowanie kalafiora",
+          "cooking_hob_program_dish_cookingsensor_boilingchicken": "Czujnik gotowania: Gotowanie kurczaka",
+          "cooking_hob_program_dish_cookingsensor_boilinggreenbeans": "Czujnik gotowania: Gotowanie fasolki szparagowej",
+          "cooking_hob_program_dish_cookingsensor_boilingmeatballs": "Czujnik gotowania: Gotowanie pulpetów",
+          "cooking_hob_program_dish_cookingsensor_boilingpotatoes": "Czujnik gotowania: Gotowanie ziemniaków",
+          "cooking_hob_program_dish_cookingsensor_chickeninpressurecooker": "Czujnik gotowania: Kurczak w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_chickpeas": "Czujnik gotowania: Ciecierzyca",
+          "cooking_hob_program_dish_cookingsensor_chickpeasinpressurecooker": "Czujnik gotowania: Ciecierzyca w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_chocolatepudding": "Czujnik gotowania: Budyń czekoladowy",
+          "cooking_hob_program_dish_cookingsensor_compote": "Czujnik gotowania: Kompot",
+          "cooking_hob_program_dish_cookingsensor_creamsoups": "Czujnik gotowania: Zupy kremowe",
+          "cooking_hob_program_dish_cookingsensor_deepfryingberliners": "Czujnik gotowania: Głębokie smażenie: pączki berlińskie",
+          "cooking_hob_program_dish_cookingsensor_deepfryingbreadedfish": "Czujnik gotowania: Głębokie smażenie: ryba panierowana",
+          "cooking_hob_program_dish_cookingsensor_deepfryingbreadedmushrooms": "Czujnik gotowania: Głębokie smażenie: grzyby panierowane",
+          "cooking_hob_program_dish_cookingsensor_deepfryingbreadedvegetables": "Czujnik gotowania: Głębokie smażenie: warzywa panierowane",
+          "cooking_hob_program_dish_cookingsensor_deepfryingbunuelos": "Czujnik gotowania: Głębokie smażenie: buñuelos",
+          "cooking_hob_program_dish_cookingsensor_deepfryingchickenportions": "Czujnik gotowania: Głębokie smażenie: porcje kurczaka",
+          "cooking_hob_program_dish_cookingsensor_deepfryingdonuts": "Czujnik gotowania: Głębokie smażenie: pączki",
+          "cooking_hob_program_dish_cookingsensor_deepfryingfishinbeerbatter": "Czujnik gotowania: Głębokie smażenie: ryba w cieście piwnym",
+          "cooking_hob_program_dish_cookingsensor_deepfryingfrenchfriesfrozen": "Czujnik gotowania: Głębokie smażenie: frytki (mrożone)",
+          "cooking_hob_program_dish_cookingsensor_deepfryingmeatballs": "Czujnik gotowania: Głębokie smażenie: pulpety",
+          "cooking_hob_program_dish_cookingsensor_deepfryingmushroomsinbeerbatter": "Czujnik gotowania: Głębokie smażenie: grzyby w cieście piwnym",
+          "cooking_hob_program_dish_cookingsensor_deepfryingvegetablesinbeerbatter": "Czujnik gotowania: Głębokie smażenie: warzywa w cieście piwnym",
+          "cooking_hob_program_dish_cookingsensor_greenbeansfrozen": "Czujnik gotowania: Fasolka szparagowa (mrożona)",
+          "cooking_hob_program_dish_cookingsensor_heatingupgoulashsoup": "Czujnik gotowania: Podgrzewanie zupy gulaszowej",
+          "cooking_hob_program_dish_cookingsensor_heatinguphotspicedwine": "Czujnik gotowania: Podgrzewanie grzańca",
+          "cooking_hob_program_dish_cookingsensor_heatingupmilk": "Czujnik gotowania: Podgrzewanie mleka",
+          "cooking_hob_program_dish_cookingsensor_homemadestock": "Czujnik gotowania: Domowy wywar",
+          "cooking_hob_program_dish_cookingsensor_homemadestockinpressurecooker": "Czujnik gotowania: Domowy wywar w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_instantsoups": "Czujnik gotowania: Zupy błyskawiczne",
+          "cooking_hob_program_dish_cookingsensor_lentils": "Czujnik gotowania: Soczewica",
+          "cooking_hob_program_dish_cookingsensor_lentilsinpressurecooker": "Czujnik gotowania: Soczewica w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_pasta": "Czujnik gotowania: Makaron",
+          "cooking_hob_program_dish_cookingsensor_peas": "Czujnik gotowania: Groszek",
+          "cooking_hob_program_dish_cookingsensor_polenta": "Czujnik gotowania: Polenta",
+          "cooking_hob_program_dish_cookingsensor_porridgesoats": "Czujnik gotowania: Owsianka",
+          "cooking_hob_program_dish_cookingsensor_potatodumplings": "Czujnik gotowania: Kluski ziemniaczane",
+          "cooking_hob_program_dish_cookingsensor_potatoesinpressurecooker": "Czujnik gotowania: Ziemniaki w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_rice": "Czujnik gotowania: Ryż",
+          "cooking_hob_program_dish_cookingsensor_riceinpressurecooker": "Czujnik gotowania: Ryż w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_ricepudding": "Czujnik gotowania: Ryż na mleku",
+          "cooking_hob_program_dish_cookingsensor_sauteedfish": "Czujnik gotowania: Ryba saute",
+          "cooking_hob_program_dish_cookingsensor_semolinapuree": "Czujnik gotowania: Puree mannowe",
+          "cooking_hob_program_dish_cookingsensor_simmeringsausages": "Czujnik gotowania: Duszenie kiełbasek",
+          "cooking_hob_program_dish_cookingsensor_stuffedpasta": "Czujnik gotowania: Makaron nadziewany",
+          "cooking_hob_program_dish_cookingsensor_vegetablesinpressurecooker": "Czujnik gotowania: Warzywa w szybkowarze",
+          "cooking_hob_program_dish_cookingsensor_vegetableswithcreamfrozen": "Czujnik gotowania: Warzywa ze śmietaną (mrożone)",
+          "cooking_hob_program_dish_fryingsensor_aubergines": "Czujnik smażenia: Bakłażany",
+          "cooking_hob_program_dish_fryingsensor_bacon": "Czujnik smażenia: Bekon",
+          "cooking_hob_program_dish_fryingsensor_bechamelsauce": "Czujnik smażenia: Sos beszamelowy",
+          "cooking_hob_program_dish_fryingsensor_camembertfrozen": "Czujnik smażenia: Camembert (mrożony)",
+          "cooking_hob_program_dish_fryingsensor_cheesesauce": "Czujnik smażenia: Sos serowy",
+          "cooking_hob_program_dish_fryingsensor_chickennuggetsfrozen": "Czujnik smażenia: Nuggets z kurczaka (mrożone)",
+          "cooking_hob_program_dish_fryingsensor_chop": "Czujnik smażenia: Kotlet",
+          "cooking_hob_program_dish_fryingsensor_cordonbleu": "Czujnik smażenia: Cordon Bleu",
+          "cooking_hob_program_dish_fryingsensor_cordonbleufrozen": "Czujnik smażenia: Cordon Bleu (mrożony)",
+          "cooking_hob_program_dish_fryingsensor_courgettes": "Czujnik smażenia: Cukinia",
+          "cooking_hob_program_dish_fryingsensor_driedreadymeals": "Czujnik smażenia: Gotowe posiłki (suszone)",
+          "cooking_hob_program_dish_fryingsensor_escalope": "Czujnik smażenia: Eskalopek",
+          "cooking_hob_program_dish_fryingsensor_escalopebreaded": "Czujnik smażenia: Panierowany eskalopek",
+          "cooking_hob_program_dish_fryingsensor_escalopefrozen": "Czujnik smażenia: Eskalopki (mrożone)",
+          "cooking_hob_program_dish_fryingsensor_fillet": "Czujnik smażenia: Filet",
+          "cooking_hob_program_dish_fryingsensor_fishfilletbreaded": "Czujnik smażenia: Panierowany filet rybny",
+          "cooking_hob_program_dish_fryingsensor_fishfilletbreadedfrozen": "Czujnik smażenia: Filet rybny panierowany (mrożony)",
+          "cooking_hob_program_dish_fryingsensor_fishfilletplain": "Czujnik smażenia: Filet rybny (bez panierki)",
+          "cooking_hob_program_dish_fryingsensor_fishfilletplainfrozen": "Czujnik smażenia: Filet rybny naturalny (mrożony)",
+          "cooking_hob_program_dish_fryingsensor_fishfingersfrozen": "Czujnik smażenia: Paluszki rybne (mrożone)",
+          "cooking_hob_program_dish_fryingsensor_frenchfriesmadefromrawpotatoes": "Czujnik smażenia: Frytki ze świeżych ziemniaków",
+          "cooking_hob_program_dish_fryingsensor_frenchtoast": "Czujnik smażenia: French Toast",
+          "cooking_hob_program_dish_fryingsensor_friedeggsinbutter": "Czujnik smażenia: Jajka sadzone na maśle",
+          "cooking_hob_program_dish_fryingsensor_friedeggsinoil": "Czujnik smażenia: Jajka sadzone na oleju",
+          "cooking_hob_program_dish_fryingsensor_fryingcamembert": "Czujnik smażenia: Smażony camembert",
+          "cooking_hob_program_dish_fryingsensor_fryingcroutons": "Czujnik smażenia: Grzanki",
+          "cooking_hob_program_dish_fryingsensor_fryingfishwhole": "Czujnik smażenia: Cała ryba (smażona)",
+          "cooking_hob_program_dish_fryingsensor_fryingfrenchfriesfrozen": "Czujnik smażenia: Mrożone frytki",
+          "cooking_hob_program_dish_fryingsensor_fryinggreenasparagus": "Czujnik smażenia: Zielone szparagi",
+          "cooking_hob_program_dish_fryingsensor_fryingmeatballs": "Czujnik smażenia: Pulpety",
+          "cooking_hob_program_dish_fryingsensor_fryingpotatoesboiledintheirskin": "Czujnik smażenia: Ziemniaki gotowane w łupinach",
+          "cooking_hob_program_dish_fryingsensor_fryingpreboiledsausages": "Czujnik smażenia: Parzone kiełbaski",
+          "cooking_hob_program_dish_fryingsensor_fryingrawsausages": "Czujnik smażenia: Surowe kiełbaski",
+          "cooking_hob_program_dish_fryingsensor_fryingrissoles": "Czujnik smażenia: Kotleciki mielone",
+          "cooking_hob_program_dish_fryingsensor_garlic": "Czujnik smażenia: Czosnek",
+          "cooking_hob_program_dish_fryingsensor_glazedonions": "Czujnik smażenia: Cebula w glazurze",
+          "cooking_hob_program_dish_fryingsensor_glazedpotatoes": "Czujnik smażenia: Ziemniaki w glazurze",
+          "cooking_hob_program_dish_fryingsensor_glazedvegetables": "Czujnik smażenia: Warzywa w glazurze",
+          "cooking_hob_program_dish_fryingsensor_gyros": "Czujnik smażenia: Gyros",
+          "cooking_hob_program_dish_fryingsensor_gyrosfrozen": "Czujnik smażenia: Gyros (mrożony)",
+          "cooking_hob_program_dish_fryingsensor_hamburgers": "Czujnik smażenia: Hamburgery",
+          "cooking_hob_program_dish_fryingsensor_kebabfrozen": "Czujnik smażenia: Kebab (mrożony)",
+          "cooking_hob_program_dish_fryingsensor_meatloaf": "Czujnik smażenia: Pieczeń rzymska",
+          "cooking_hob_program_dish_fryingsensor_mincedmeat": "Czujnik smażenia: Mięso mielone",
+          "cooking_hob_program_dish_fryingsensor_mushrooms": "Czujnik smażenia: Grzyby",
+          "cooking_hob_program_dish_fryingsensor_omelettes": "Czujnik smażenia: Omlety",
+          "cooking_hob_program_dish_fryingsensor_pancake": "Czujnik smażenia: Naleśnik",
+          "cooking_hob_program_dish_fryingsensor_pancakes": "Czujnik smażenia: Naleśniki",
+          "cooking_hob_program_dish_fryingsensor_peppers": "Czujnik smażenia: Papryka",
+          "cooking_hob_program_dish_fryingsensor_potatopancakes": "Czujnik smażenia: Placki ziemniaczane",
+          "cooking_hob_program_dish_fryingsensor_poultrybreast": "Czujnik smażenia: Pierś drobiowa",
+          "cooking_hob_program_dish_fryingsensor_poultrybreastfrozen": "Czujnik smażenia: Pierś drobiowa (mrożona)",
+          "cooking_hob_program_dish_fryingsensor_prawns": "Czujnik smażenia: Krewetki",
+          "cooking_hob_program_dish_fryingsensor_reducingsauces": "Czujnik smażenia: Redukowanie sosów",
+          "cooking_hob_program_dish_fryingsensor_sauteingvegetablesinoil": "Czujnik smażenia: Podsmażane warzywa",
+          "cooking_hob_program_dish_fryingsensor_scampi": "Czujnik smażenia: Krewetki scampi",
+          "cooking_hob_program_dish_fryingsensor_scrambledeggs": "Czujnik smażenia: Jajecznica",
+          "cooking_hob_program_dish_fryingsensor_springrollsfrozen": "Czujnik smażenia: Sajgonki (mrożone)",
+          "cooking_hob_program_dish_fryingsensor_steaksmedium": "Czujnik smażenia: Steki (średnio wysmażone)",
+          "cooking_hob_program_dish_fryingsensor_steaksrare": "Czujnik smażenia: Steki (krwiste)",
+          "cooking_hob_program_dish_fryingsensor_steakswelldone": "Czujnik smażenia: Steki (dobrze wysmażone)",
+          "cooking_hob_program_dish_fryingsensor_stirfriesfrozen": "Czujnik smażenia: Stir-Fry (mrożone)",
+          "cooking_hob_program_dish_fryingsensor_stripsofmeat": "Czujnik smażenia: Paski mięsa",
+          "cooking_hob_program_dish_fryingsensor_sweetsauces": "Czujnik smażenia: Słodkie sosy",
+          "cooking_hob_program_dish_fryingsensor_swissroesti": "Czujnik smażenia: Rösti szwajcarskie",
+          "cooking_hob_program_dish_fryingsensor_toastingalmonds": "Czujnik smażenia: Prażenie migdałów",
+          "cooking_hob_program_dish_fryingsensor_toastingnuts": "Czujnik smażenia: Prażenie orzechów",
+          "cooking_hob_program_dish_fryingsensor_toastingpinenuts": "Czujnik smażenia: Prażenie orzeszków piniowych",
+          "cooking_hob_program_dish_fryingsensor_tomatosaucewithvegetables": "Czujnik smażenia: Sos pomidorowy z warzywami",
+          "cooking_hob_program_dish_fryingsensor_vienneseschnitzel": "Czujnik smażenia: Sznycel wiedeński",
+          "cooking_hob_program_fryingsensormode": "Tryb czujnika smażenia",
+          "cooking_hob_program_powerlevelmode": "Tryb poziomu mocy",
+          "cooking_hob_program_powermovemode": "Tryb PowerMove",
+          "cooking_oven_program_heatingmode_bottomheating": "Nagrzewanie dolne",
+          "cooking_oven_program_heatingmode_frozenheatupspecial": "Funkcja coolstart",
+          "cooking_oven_program_heatingmode_grillargearea": "Grillowanie, duży obszar",
+          "cooking_oven_program_heatingmode_grillsmallarea": "Grillowanie, mały obszar",
+          "cooking_oven_program_heatingmode_hotair": "Termoobieg",
+          "cooking_oven_program_heatingmode_hotaireco": "Termoobieg eco",
+          "cooking_oven_program_heatingmode_hotairgrilling": "Grillowanie z termoobiegiem",
+          "cooking_oven_program_heatingmode_keepwarm": "Podtrzymywanie ciepła",
+          "cooking_oven_program_heatingmode_pizzasetting": "Ustawienie pizza",
+          "cooking_oven_program_heatingmode_preheatovenware": "Podgrzewanie naczyń",
+          "cooking_oven_program_heatingmode_sabbathprogramme": "Program szabatu",
+          "cooking_oven_program_heatingmode_slowcook": "Wolne gotowanie",
+          "cooking_oven_program_heatingmode_topbottomheating": "Grzanie górne i dolne",
+          "cooking_oven_program_heatingmode_topbottomheatingeco": "Grzanie górne i dolne eco",
+          "cooking_oven_program_microwave_90watt": "Mikrofalówka 90 W",
+          "cooking_oven_program_microwave_180watt": "Mikrofalówka 180 W",
+          "cooking_oven_program_microwave_360watt": "Mikrofalówka 360 W",
+          "cooking_oven_program_microwave_600watt": "Mikrofalówka 600 W",
+          "cooking_oven_program_microwave_max": "Mikrofalówka – maks.",
+          "cooking_oven_program_cleaning_drying": "Czyszczenie: Suszenie",
+          "cooking_oven_program_cleaning_easyclean": "Czyszczenie: EasyClean",
+          "cooking_oven_program_cleaning_pyrolysis": "Czyszczenie: Pyroliza",
+          "cooking_oven_program_dish_automatic_conv_beefroulade": "Auto: Roladka wołowa",
+          "cooking_oven_program_dish_automatic_conv_belly": "Auto: Boczek wieprzowy",
+          "cooking_oven_program_dish_automatic_conv_bonelesslegoflambmedium": "Auto: Udziec jagnięcy bez kości (średni)",
+          "cooking_oven_program_dish_automatic_conv_bonelesslegoflambwelldone": "Auto: Udziec jagnięcy bez kości (wypieczony)",
+          "cooking_oven_program_dish_automatic_conv_bonelesslegofroevenison": "Auto: Udziec sarny bez kości",
+          "cooking_oven_program_dish_automatic_conv_bonelesslegofvenison": "Auto: Udziec jelenia bez kości",
+          "cooking_oven_program_dish_automatic_conv_bonelessporkneckjoint": "Auto: Karkówka bez kości",
+          "cooking_oven_program_dish_automatic_conv_fishwholestew": "Auto: Cała ryba (duszona)",
+          "cooking_oven_program_dish_automatic_conv_goosebreast": "Auto: Pierś gęsi",
+          "cooking_oven_program_dish_automatic_conv_gooselegs": "Auto: Udka gęsi",
+          "cooking_oven_program_dish_automatic_conv_goulash": "Auto: Gulasz",
+          "cooking_oven_program_dish_automatic_conv_jointofporkwithcracklingegshoulder": "Auto: Łopatka wieprzowa ze skórką",
+          "cooking_oven_program_dish_automatic_conv_jointofveallean": "Auto: Cielęcina (chuda)",
+          "cooking_oven_program_dish_automatic_conv_jointofvealmarbled": "Auto: Cielęcina (marmurkowa)",
+          "cooking_oven_program_dish_automatic_conv_knuckleofveal": "Auto: Gicz cielęca",
+          "cooking_oven_program_dish_automatic_conv_legoflambonthebonewelldone": "Auto: Udziec jagnięcy z kością (wypieczony)",
+          "cooking_oven_program_dish_automatic_conv_meatloafmadefromfreshmincedmeat": "Auto: Pieczeń rzymska ze świeżego mięsa mielonego",
+          "cooking_oven_program_dish_automatic_conv_microwave_bakesavouryfreshcookedingredients": "Auto (mikrofalówka): Zapiekanka wytrawna (świeże/gotowane składniki)",
+          "cooking_oven_program_dish_automatic_conv_microwave_bakesweetfresh": "Auto (mikrofalówka): Zapiekanka słodka (świeża)",
+          "cooking_oven_program_dish_automatic_conv_microwave_bonelesslegoflambmedium": "Auto (mikrofalówka): Udziec jagnięcy bez kości (średni)",
+          "cooking_oven_program_dish_automatic_conv_microwave_bonelesslegoflambwelldone": "Auto (mikrofalówka): Udziec jagnięcy bez kości (wypieczony)",
+          "cooking_oven_program_dish_automatic_conv_microwave_bonelessporkneckjoint": "Auto (mikrofalówka): Karkówka bez kości",
+          "cooking_oven_program_dish_automatic_conv_microwave_cannelloni": "Auto (mikrofalówka): Cannelloni",
+          "cooking_oven_program_dish_automatic_conv_microwave_chickengoujonsnuggets": "Auto (mikrofalówka): Goujons/Nuggets z kurczaka",
+          "cooking_oven_program_dish_automatic_conv_microwave_chickenlegswithvegetables": "Auto (mikrofalówka): Udka z kurczaka z warzywami",
+          "cooking_oven_program_dish_automatic_conv_microwave_chickenparts": "Auto (mikrofalówka): Części kurczaka",
+          "cooking_oven_program_dish_automatic_conv_microwave_chips": "Auto (mikrofalówka): Frytki",
+          "cooking_oven_program_dish_automatic_conv_microwave_croquettes": "Auto (mikrofalówka): Krokiety",
+          "cooking_oven_program_dish_automatic_conv_microwave_defrostbreadrolls": "Auto (mikrofalówka): Rozmrażanie bułek",
+          "cooking_oven_program_dish_automatic_conv_microwave_halvedchicken": "Auto (mikrofalówka): Połówka kurczaka",
+          "cooking_oven_program_dish_automatic_conv_microwave_lasagnefrozen": "Auto (mikrofalówka): Lazania (mrożona)",
+          "cooking_oven_program_dish_automatic_conv_microwave_meatloafmadefromfreshmincedmeat": "Auto (mikrofalówka): Pieczeń rzymska ze świeżego mięsa mielonego",
+          "cooking_oven_program_dish_automatic_conv_microwave_minipizzas": "Auto (mikrofalówka): Mini pizze",
+          "cooking_oven_program_dish_automatic_conv_microwave_partcookedbreadrollsorbaguettefrozen": "Auto (mikrofalówka): Podpieczone bułki/bagietki (mrożone)",
+          "cooking_oven_program_dish_automatic_conv_microwave_pizzathickcrust1slicefrozen": "Auto (mikrofalówka): Pizza gruby spód 1 kawałek (mrożona)",
+          "cooking_oven_program_dish_automatic_conv_microwave_pizzathincrust1slice": "Auto (mikrofalówka): Pizza cienki spód 1 kawałek",
+          "cooking_oven_program_dish_automatic_conv_microwave_potatogratinrawingredients4cmdeep": "Auto (mikrofalówka): Gratin ziemniaczany (surowe składniki, 4 cm)",
+          "cooking_oven_program_dish_automatic_conv_microwave_potatopocketsfilled": "Auto (mikrofalówka): Nadziewane kieszonki ziemniaczane",
+          "cooking_oven_program_dish_automatic_conv_microwave_sirloinmedium": "Auto (mikrofalówka): Rostbef (średni)",
+          "cooking_oven_program_dish_automatic_conv_microwave_squidringsbreaded": "Auto (mikrofalówka): Panierowane pierścienie kalmara",
+          "cooking_oven_program_dish_automatic_conv_microwave_turkeybreast": "Auto (mikrofalówka): Pierś indyka",
+          "cooking_oven_program_dish_automatic_conv_microwave_unstuffedchicken": "Auto (mikrofalówka): Kurczak (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_microwave_wholebakedpotatoes": "Auto (mikrofalówka): Pieczone całe ziemniaki",
+          "cooking_oven_program_dish_automatic_conv_pavlova": "Auto: Beza Pavlova",
+          "cooking_oven_program_dish_automatic_conv_porkchopfryonthebone": "Auto: Kotlet wieprzowy z kością",
+          "cooking_oven_program_dish_automatic_conv_potroastedbeef": "Auto: Wołowina duszona",
+          "cooking_oven_program_dish_automatic_conv_poulardunstuffed": "Auto: Pularada (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_roastjoint": "Auto: Pieczona pieczeń",
+          "cooking_oven_program_dish_automatic_conv_roastporkloin": "Auto: Pieczeń wieprzowa (schab)",
+          "cooking_oven_program_dish_automatic_conv_rolledporkjoint": "Auto: Zwijana pieczeń wieprzowa",
+          "cooking_oven_program_dish_automatic_conv_salmonfillet": "Auto: Filet z łososia",
+          "cooking_oven_program_dish_automatic_conv_scandinavianchristmasham": "Auto: Skandynawska szynka bożonarodzeniowa",
+          "cooking_oven_program_dish_automatic_conv_sirloinmedium": "Auto: Rostbef (średni)",
+          "cooking_oven_program_dish_automatic_conv_sirloinrare": "Auto: Rostbef (krwisty)",
+          "cooking_oven_program_dish_automatic_conv_slowroastjoint": "Auto: Powolna pieczeń",
+          "cooking_oven_program_dish_automatic_conv_stewwithmeat": "Auto: Gulasz z mięsem",
+          "cooking_oven_program_dish_automatic_conv_stewwithvegetables": "Auto: Gulasz z warzywami",
+          "cooking_oven_program_dish_automatic_conv_turkeybreast": "Auto: Pierś indyka",
+          "cooking_oven_program_dish_automatic_conv_unstuffedchicken": "Auto: Kurczak (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_unstuffedduck": "Auto: Kaczka (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_unstuffedgoose": "Auto: Gęś (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_unstuffedsmallturkey": "Auto: Mały indyk (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_vealossobuco": "Auto: Ossobuco z cielęciny",
+          "cooking_oven_program_dish_automatic_conv_wholerabbit": "Auto: Cały królik",
+          "cooking_oven_program_dish_automatic_conv_wildboarroast": "Auto: Pieczeń z dzika",
+          "cooking_oven_program_dish_automatic_microwave_basmatirice": "Auto (mikrofalówka): Ryż basmati",
+          "cooking_oven_program_dish_automatic_microwave_boiledpotatoes": "Auto (mikrofalówka): Ziemniaki gotowane",
+          "cooking_oven_program_dish_automatic_microwave_boiledpotatoeswskin": "Auto (mikrofalówka): Ziemniaki gotowane w mundurkach",
+          "cooking_oven_program_dish_automatic_microwave_brownrice": "Auto (mikrofalówka): Ryż brązowy",
+          "cooking_oven_program_dish_automatic_microwave_cakedrydefrost": "Auto (mikrofalówka): Rozmrażanie ciasta (suche)",
+          "cooking_oven_program_dish_automatic_microwave_couscous": "Auto (mikrofalówka): Kuskus",
+          "cooking_oven_program_dish_automatic_microwave_defrostcakesmoist": "Auto (mikrofalówka): Rozmrażanie ciast (wilgotnych)",
+          "cooking_oven_program_dish_automatic_microwave_defrostfishfillet": "Auto (mikrofalówka): Rozmrażanie filetu rybnego",
+          "cooking_oven_program_dish_automatic_microwave_defrostfishwhole": "Auto (mikrofalówka): Rozmrażanie ryby w całości",
+          "cooking_oven_program_dish_automatic_microwave_defrostmeat": "Auto (mikrofalówka): Rozmrażanie mięsa",
+          "cooking_oven_program_dish_automatic_microwave_defrostmultigrainbread": "Auto (mikrofalówka): Rozmrażanie chleba wieloziarnistego",
+          "cooking_oven_program_dish_automatic_microwave_defrostpoultryportions": "Auto (mikrofalówka): Rozmrażanie porcji drobiu",
+          "cooking_oven_program_dish_automatic_microwave_defrostspinach": "Auto (mikrofalówka): Rozmrażanie szpinaku",
+          "cooking_oven_program_dish_automatic_microwave_defrostwhitebread": "Auto (mikrofalówka): Rozmrażanie chleba pszennego",
+          "cooking_oven_program_dish_automatic_microwave_defrostveg": "Auto (mikrofalówka): Rozmrażanie warzyw",
+          "cooking_oven_program_dish_automatic_microwave_defrostberries": "Auto (mikrofalówka): Rozmrażanie owoców jagodowych",
+          "cooking_oven_program_dish_automatic_microwave_defrostmincedmeat": "Auto (mikrofalówka): Rozmrażanie mięsa mielonego",
+          "cooking_oven_program_dish_automatic_microwave_defrostpoultry": "Auto (mikrofalówka): Rozmrażanie drobiu",
+          "cooking_oven_program_dish_automatic_microwave_defrostsoup": "Auto (mikrofalówka): Rozmrażanie zupy",
+          "cooking_oven_program_dish_automatic_microwave_dissolvegelatine": "Auto (mikrofalówka): Rozpuszczanie żelatyny",
+          "cooking_oven_program_dish_automatic_microwave_dissolveyeast": "Auto (mikrofalówka): Rozpuszczanie drożdży",
+          "cooking_oven_program_dish_automatic_microwave_heatupbeverages": "Auto (mikrofalówka): Podgrzewanie napojów",
+          "cooking_oven_program_dish_automatic_microwave_heatupplatedmeal": "Auto (mikrofalówka): Podgrzewanie posiłku na talerzu",
+          "cooking_oven_program_dish_automatic_microwave_longgrainrice": "Auto (mikrofalówka): Ryż długoziarnisty",
+          "cooking_oven_program_dish_automatic_microwave_meltbutter": "Auto (mikrofalówka): Rozpuszczanie masła",
+          "cooking_oven_program_dish_automatic_microwave_meltchocolate": "Auto (mikrofalówka): Rozpuszczanie czekolady",
+          "cooking_oven_program_dish_automatic_microwave_meltcookingchocolate": "Auto (mikrofalówka): Rozpuszczanie czekolady kuchennej",
+          "cooking_oven_program_dish_automatic_microwave_milletorquinoa": "Auto (mikrofalówka): Kasza jaglana lub komosa ryżowa",
+          "cooking_oven_program_dish_automatic_microwave_mixedgrain": "Auto (mikrofalówka): Mieszanka zbóż",
+          "cooking_oven_program_dish_automatic_microwave_oatmealorricepudding": "Auto (mikrofalówka): Owsianka lub ryż na mleku",
+          "cooking_oven_program_dish_automatic_microwave_polenta": "Auto (mikrofalówka): Polenta",
+          "cooking_oven_program_dish_automatic_microwave_popcorn": "Auto (mikrofalówka): Popcorn",
+          "cooking_oven_program_dish_automatic_microwave_semolinapudding": "Auto (mikrofalówka): Budyń mannowy",
+          "cooking_oven_program_dish_automatic_microwave_softenbutter": "Auto (mikrofalówka): Zmiękczanie masła",
+          "cooking_oven_program_dish_automatic_microwave_softenicecream": "Auto (mikrofalówka): Zmiękczanie lodów",
+          "cooking_oven_program_dish_automatic_microwave_spinachleavescauliflowerflorets": "Auto (mikrofalówka): Liście szpinaku/Różyczki kalafiora",
+          "cooking_oven_program_dish_automatic_microwave_steambroccoli": "Auto (mikrofalówka): Gotowanie brokułów na parze",
+          "cooking_oven_program_dish_automatic_microwave_steambrusselsprouts": "Auto (mikrofalówka): Gotowanie brukselki na parze",
+          "cooking_oven_program_dish_automatic_microwave_steamcarrots": "Auto (mikrofalówka): Gotowanie marchewki na parze",
+          "cooking_oven_program_dish_automatic_microwave_steamfennel": "Auto (mikrofalówka): Gotowanie kopru włoskiego na parze",
+          "cooking_oven_program_dish_automatic_microwave_steamfishfillet": "Auto (mikrofalówka): Gotowanie filetu rybnego na parze",
+          "cooking_oven_program_dish_automatic_microwave_steamgreenbeans": "Auto (mikrofalówka): Gotowanie fasolki szparagowej na parze",
+          "cooking_oven_program_dish_automatic_microwave_steamkohlrabi": "Auto (mikrofalówka): Gotowanie kalarepy na parze",
+          "cooking_oven_program_dish_automatic_microwave_steampeas": "Auto (mikrofalówka): Gotowanie groszku na parze",
+          "cooking_oven_program_dish_automatic_microwave_steamzucchini": "Auto (mikrofalówka): Gotowanie cukinii na parze",
+          "cooking_oven_program_dish_automatic_microwave_warmupbabyfood": "Auto (mikrofalówka): Podgrzewanie jedzenia dla dzieci",
+          "cooking_oven_program_dish_bakingsensor_applecakecovered": "Czujnik pieczenia: Szarlotka (kryta)",
+          "cooking_oven_program_dish_bakingsensor_applecakeopen": "Czujnik pieczenia: Szarlotka (odkryta)",
+          "cooking_oven_program_dish_bakingsensor_applepie": "Czujnik pieczenia: Szarlotka",
+          "cooking_oven_program_dish_bakingsensor_beefburgers": "Czujnik pieczenia: Burgery wołowe",
+          "cooking_oven_program_dish_bakingsensor_bread": "Czujnik pieczenia: Chleb",
+          "cooking_oven_program_dish_bakingsensor_brownies": "Czujnik pieczenia: Brownie",
+          "cooking_oven_program_dish_bakingsensor_bunschouxbuns": "Czujnik pieczenia: Bułeczki/Ptysie",
+          "cooking_oven_program_dish_bakingsensor_cheesecake": "Czujnik pieczenia: Sernik",
+          "cooking_oven_program_dish_bakingsensor_cheesecaketall": "Czujnik pieczenia: Sernik (wysoki)",
+          "cooking_oven_program_dish_bakingsensor_christmasstollen": "Czujnik pieczenia: Strucla świąteczna",
+          "cooking_oven_program_dish_bakingsensor_creamsponge": "Czujnik pieczenia: Biszkopt ze śmietaną",
+          "cooking_oven_program_dish_bakingsensor_croissantsyeast": "Czujnik pieczenia: Croissanty (drożdżowe)",
+          "cooking_oven_program_dish_bakingsensor_cupcakesmuffins": "Czujnik pieczenia: Babeczki/Muffinki",
+          "cooking_oven_program_dish_bakingsensor_flatbreadpita": "Czujnik pieczenia: Placek płaski/Pita",
+          "cooking_oven_program_dish_bakingsensor_fruitflanbaking": "Czujnik pieczenia: Tarta owocowa",
+          "cooking_oven_program_dish_bakingsensor_gateausponge": "Czujnik pieczenia: Biszkopt tortowy",
+          "cooking_oven_program_dish_bakingsensor_lasagnecooked": "Czujnik pieczenia: Lazania (ugotowana)",
+          "cooking_oven_program_dish_bakingsensor_lasagneraw": "Czujnik pieczenia: Lazania (surowa)",
+          "cooking_oven_program_dish_bakingsensor_loafcake": "Czujnik pieczenia: Ciasto w keksówce",
+          "cooking_oven_program_dish_bakingsensor_marblesponge": "Czujnik pieczenia: Ciasto marmurkowe",
+          "cooking_oven_program_dish_bakingsensor_meatball": "Czujnik pieczenia: Pulpet",
+          "cooking_oven_program_dish_bakingsensor_partcookedbaguettes": "Czujnik pieczenia: Podpieczone bagietki",
+          "cooking_oven_program_dish_bakingsensor_partcookedrolls": "Czujnik pieczenia: Podpieczone bułki",
+          "cooking_oven_program_dish_bakingsensor_pizza": "Czujnik pieczenia: Pizza",
+          "cooking_oven_program_dish_bakingsensor_plainsponge": "Czujnik pieczenia: Biszkopt naturalny",
+          "cooking_oven_program_dish_bakingsensor_potatogratin": "Czujnik pieczenia: Zapiekanka ziemniaczana",
+          "cooking_oven_program_dish_bakingsensor_quiche": "Czujnik pieczenia: Quiche",
+          "cooking_oven_program_dish_bakingsensor_ringcake": "Czujnik pieczenia: Baba/keks pierścieniowy",
+          "cooking_oven_program_dish_bakingsensor_roastbeefmedium": "Czujnik pieczenia: Rostbef (średni)",
+          "cooking_oven_program_dish_bakingsensor_roastbeefrare": "Czujnik pieczenia: Rostbef (krwisty)",
+          "cooking_oven_program_dish_bakingsensor_roastbeefwelldone": "Czujnik pieczenia: Rostbef (wypieczony)",
+          "cooking_oven_program_dish_bakingsensor_rolls": "Czujnik pieczenia: Bułki",
+          "cooking_oven_program_dish_bakingsensor_schweinebraten": "Czujnik pieczenia: Schweinebraten",
+          "cooking_oven_program_dish_bakingsensor_shortcrust": "Czujnik pieczenia: Ciasto kruche",
+          "cooking_oven_program_dish_bakingsensor_smallbiscuits": "Czujnik pieczenia: Małe ciastka",
+          "cooking_oven_program_dish_bakingsensor_souffle": "Czujnik pieczenia: Suflet",
+          "cooking_oven_program_dish_bakingsensor_streuselkuchen": "Czujnik pieczenia: Streuselkuchen",
+          "cooking_oven_program_dish_bakingsensor_swiss_roll": "Czujnik pieczenia: Rolada biszkoptowa",
+          "cooking_oven_program_dish_bakingsensor_tinloaf": "Czujnik pieczenia: Chleb w keksówce",
+          "cooking_oven_program_dish_bakingsensor_veggieburgers": "Czujnik pieczenia: Burgery warzywne",
+          "cooking_oven_program_dish_bakingsensor_whitebread": "Czujnik pieczenia: Chleb biały",
+          "cooking_oven_program_dish_bakingsensor_wholemealspeltbread": "Czujnik pieczenia: Chleb razowy/orkiszowy",
+          "cooking_oven_program_dish_bakingsensor_yeastdough": "Czujnik pieczenia: Ciasto drożdżowe",
+          "cooking_oven_program_dish_meatprobe_beeffiletmedium": "Sonda mięsna: Filet wołowy (średni)",
+          "cooking_oven_program_dish_meatprobe_beeffiletrare": "Sonda mięsna: Filet wołowy (krwisty)",
+          "cooking_oven_program_dish_meatprobe_beeffiletwelldone": "Sonda mięsna: Filet wołowy (wypieczony)",
+          "cooking_oven_program_dish_meatprobe_beefroast": "Sonda mięsna: Pieczeń wołowa",
+          "cooking_oven_program_dish_meatprobe_duckbreast": "Sonda mięsna: Pierś kaczki",
+          "cooking_oven_program_dish_meatprobe_fish": "Sonda mięsna: Ryba",
+          "cooking_oven_program_dish_meatprobe_lamblegbonein": "Sonda mięsna: Udziec jagnięcy z kością",
+          "cooking_oven_program_dish_meatprobe_lamblegboneless": "Sonda mięsna: Udziec jagnięcy bez kości",
+          "cooking_oven_program_dish_meatprobe_lambsaddle": "Sonda mięsna: Comber jagnięcy",
+          "cooking_oven_program_dish_meatprobe_porkbelly": "Sonda mięsna: Boczek wieprzowy",
+          "cooking_oven_program_dish_meatprobe_porkneck": "Sonda mięsna: Karkówka wieprzowa",
+          "cooking_oven_program_dish_meatprobe_porkroast": "Sonda mięsna: Pieczeń wieprzowa",
+          "cooking_oven_program_dish_meatprobe_poultrystuffed": "Sonda mięsna: Drób (nadziewany)",
+          "cooking_oven_program_dish_meatprobe_poultryunstuffed": "Sonda mięsna: Drób (bez nadzienia)",
+          "cooking_oven_program_dish_meatprobe_sirloinsteakmedium": "Sonda mięsna: Stek z rostbefu (średni)",
+          "cooking_oven_program_dish_meatprobe_sirloinsteakrare": "Sonda mięsna: Stek z rostbefu (krwisty)",
+          "cooking_oven_program_dish_meatprobe_sirloinsteakwelldone": "Sonda mięsna: Stek z rostbefu (wypieczony)",
+          "cooking_oven_program_dish_meatprobe_vealroast": "Sonda mięsna: Pieczeń cielęca",
+          "cooking_oven_program_dish_meatprobe_venison": "Sonda mięsna: Dziczyzna",
+          "cooking_oven_program_dish_meatprobe_wildboar": "Sonda mięsna: Dzik",
+          "cooking_oven_program_dish_recommendation_breadrolls": "Rekomendacja: Bułki",
+          "cooking_oven_program_dish_recommendation_cakeoncookingtray": "Rekomendacja: Ciasto na blasze",
+          "cooking_oven_program_dish_recommendation_casserole": "Rekomendacja: Zapiekanka",
+          "cooking_oven_program_dish_recommendation_chips": "Rekomendacja: Frytki",
+          "cooking_oven_program_dish_recommendation_custard": "Rekomendacja: Krem budyniowy",
+          "cooking_oven_program_dish_recommendation_fishsticks": "Rekomendacja: Paluszki rybne",
+          "cooking_oven_program_dish_recommendation_frozenpizza": "Rekomendacja: Pizza mrożona",
+          "cooking_oven_program_dish_recommendation_gratin": "Rekomendacja: Zapiekanka",
+          "cooking_oven_program_dish_recommendation_meringues": "Rekomendacja: Bezy",
+          "cooking_oven_program_dish_recommendation_ovenroast": "Rekomendacja: Pieczeń z piekarnika",
+          "cooking_oven_program_dish_recommendation_poultry": "Rekomendacja: Drób",
+          "cooking_oven_program_dish_recommendation_preserving": "Rekomendacja: Wekowanie",
+          "cooking_oven_program_dish_recommendation_quiche": "Rekomendacja: Quiche",
+          "cooking_oven_program_dish_recommendation_readymealinfan": "Rekomendacja: Danie gotowe (termoobieg)",
+          "cooking_oven_program_dish_recommendation_ringcake": "Rekomendacja: Baba/keks pierścieniowy",
+          "cooking_oven_program_dish_recommendation_souffle": "Rekomendacja: Suflet",
+          "cooking_oven_program_dish_recommendation_swissroll": "Rekomendacja: Rolada biszkoptowa",
+          "cooking_oven_program_dish_recommendation_vegetablegratin": "Rekomendacja: Zapiekanka warzywna",
+          "cooking_oven_program_dish_recommendation_wholemealbreads": "Rekomendacja: Pieczywo razowe",
+          "cooking_oven_program_heatingmode_defrost": "Rozmrażanie",
+          "cooking_oven_program_heatingmode_desiccation": "Suszenie",
+          "cooking_oven_program_heatingmode_proofdough": "Wyrastanie ciasta",
+          "cooking_oven_program_heatingmode_proof": "Wyrastanie ciasta",
+          "cooking_oven_program_heatingmode_convectionbake": "Termoobieg",
+          "cooking_oven_program_heatingmode_steamassist": "Wspomaganie parą",
+          "cooking_oven_program_heatingmode_intensiveheat": "Intensywne ciepło",
+          "cooking_oven_program_heatingmode_fullsurfacegrill": "Grill na całej powierzchni",
+          "cooking_oven_program_heatingmode_economygrill": "Grill ekonomiczny",
+          "cooking_oven_program_heatingmode_circuitedgrill": "Grill obiegowy",
+          "cooking_oven_program_heatingmode_warmingdrawer": "Szuflada do podgrzewania",
+          "cooking_oven_program_microwave_900watt": "Mikrofalówka 900 W",
+          "cooking_oven_program_microwave_1000watt": "Mikrofalówka 1000 W",
+          "cooking_oven_program_subsequentmode_subsequentmicrowavecooking": "Następny tryb: Gotowanie w mikrofalówce",
+          "cooking_oven_program_subsequentmode_subsequentbrowning": "Następny tryb: Przyrumienianie",
+          "cooking_oven_program_subsequentmode_subsequentkeepwarm": "Następny tryb: Podtrzymanie ciepła",
+          "cooking_oven_program_cleaning_descale": "Czyszczenie: Odkamienianie",
+          "cooking_oven_program_cleaning_draining": "Czyszczenie: Odprowadzanie wody",
+          "cooking_oven_program_cleaning_ecolysis": "Czyszczenie: Ekoliza",
+          "cooking_oven_program_cleaning_flushing": "Czyszczenie: Płukanie",
+          "cooking_oven_program_cleaningmodes_autosteamcalibration": "Czyszczenie: Automatyczna kalibracja pary",
+          "cooking_oven_program_heatingmode_airfry": "Air Fry",
+          "cooking_oven_program_heatingmode_grilllargearea": "Grill, duży obszar",
+          "cooking_oven_program_heatingmode_hotairgentle": "Delikatny termoobieg",
+          "cooking_oven_program_heatingmode_letrest": "Odpoczynek",
+          "cooking_oven_program_heatingmode_preheating": "Podgrzewanie wstępne",
+          "cooking_oven_program_dish_automatic_conv_bakeditems": "Auto: Wypieki",
+          "cooking_oven_program_dish_automatic_conv_bonedlegoflambmedium": "Auto: Udziec jagnięcy bez kości (średni)",
+          "cooking_oven_program_dish_automatic_conv_bread": "Auto: Chleb",
+          "cooking_oven_program_dish_automatic_conv_breadrollsbaguette": "Auto: Bułki/Bagietka",
+          "cooking_oven_program_dish_automatic_conv_pastadumplingspotatoesrice": "Auto: Makaron/Pierogi/Ziemniaki/Ryż",
+          "cooking_oven_program_dish_automatic_conv_reheatplatedmeal": "Auto: Podgrzewanie posiłku na talerzu",
+          "cooking_oven_program_dish_automatic_conv_reheatvegetables": "Auto: Podgrzewanie warzyw",
+          "cooking_oven_program_dish_automatic_conv_roastbeefenglish": "Auto: Rostbef po angielsku",
+          "cooking_oven_program_dish_automatic_conv_steam_bonelesslegoflambmedium": "Auto (para): Udziec jagnięcy bez kości (średni)",
+          "cooking_oven_program_dish_automatic_conv_steam_bonelesslegoflambwelldone": "Auto (para): Udziec jagnięcy bez kości (wypieczony)",
+          "cooking_oven_program_dish_automatic_conv_steam_bonelesslegofroevenison": "Auto (para): Udziec sarny bez kości",
+          "cooking_oven_program_dish_automatic_conv_steam_bonelesslegofvenison": "Auto (para): Udziec jelenia bez kości",
+          "cooking_oven_program_dish_automatic_conv_steam_bonelessporkneckjoint": "Auto (para): Karkówka bez kości",
+          "cooking_oven_program_dish_automatic_conv_steam_breastofvealstuffed": "Auto (para): Mostek cielęcy (nadziewany)",
+          "cooking_oven_program_dish_automatic_conv_steam_chickenparts": "Auto (para): Części kurczaka",
+          "cooking_oven_program_dish_automatic_conv_steam_fatlessspongecake": "Auto (para): Biszkopt beztłuszczowy",
+          "cooking_oven_program_dish_automatic_conv_steam_fishfilletgratinated": "Auto (para): Filet rybny zapiekany",
+          "cooking_oven_program_dish_automatic_conv_steam_fishfilletstew": "Auto (para): Filet rybny (duszony)",
+          "cooking_oven_program_dish_automatic_conv_steam_flatbread": "Auto (para): Podpłomyk",
+          "cooking_oven_program_dish_automatic_conv_steam_jointofporkwithcracklingegshoulder": "Auto (para): Łopatka wieprzowa ze skórką",
+          "cooking_oven_program_dish_automatic_conv_steam_jointofveallean": "Auto (para): Cielęcina (chuda)",
+          "cooking_oven_program_dish_automatic_conv_steam_jointofvealmarbled": "Auto (para): Cielęcina (marmurkowa)",
+          "cooking_oven_program_dish_automatic_conv_steam_knuckleofpork": "Auto (para): Golonka wieprzowa",
+          "cooking_oven_program_dish_automatic_conv_steam_knuckleofveal": "Auto (para): Gicz cielęca",
+          "cooking_oven_program_dish_automatic_conv_steam_legoflambonthebonewelldone": "Auto (para): Udziec jagnięcy z kością (wypieczony)",
+          "cooking_oven_program_dish_automatic_conv_steam_meatloafmadefromfreshmincedmeat": "Auto (para): Pieczeń rzymska ze świeżego mięsa mielonego",
+          "cooking_oven_program_dish_automatic_conv_steam_multigrainryebreadwithyeastinaloaftin": "Auto (para): Chleb żytni wieloziarnisty na drożdżach w keksówce",
+          "cooking_oven_program_dish_automatic_conv_steam_pizzawiththickbaseonepizza": "Auto (para): Pizza na grubym cieście (jedna pizza)",
+          "cooking_oven_program_dish_automatic_conv_steam_pizzawiththinbaseonepizza": "Auto (para): Pizza na cienkim cieście (jedna pizza)",
+          "cooking_oven_program_dish_automatic_conv_steam_porkchopfryonthebone": "Auto (para): Kotlet wieprzowy z kością",
+          "cooking_oven_program_dish_automatic_conv_steam_poulardunstuffed": "Auto (para): Pularada (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_steam_roastporkloin": "Auto (para): Pieczeń wieprzowa (schab)",
+          "cooking_oven_program_dish_automatic_conv_steam_roastwholefish": "Auto (para): Pieczona cała ryba",
+          "cooking_oven_program_dish_automatic_conv_steam_rolledporkjoint": "Auto (para): Zwijana pieczeń wieprzowa",
+          "cooking_oven_program_dish_automatic_conv_steam_saddleofvenisononthebone": "Auto (para): Siodło jelenia z kością",
+          "cooking_oven_program_dish_automatic_conv_steam_sirloinmedium": "Auto (para): Rostbef (średni)",
+          "cooking_oven_program_dish_automatic_conv_steam_sirloinrare": "Auto (para): Rostbef (krwisty)",
+          "cooking_oven_program_dish_automatic_conv_steam_smokedporkbonedrolledfry": "Auto (para): Wędzona wieprzowina bez kości, zrolowana",
+          "cooking_oven_program_dish_automatic_conv_steam_smokedporkonthebone": "Auto (para): Wędzona wieprzowina z kością",
+          "cooking_oven_program_dish_automatic_conv_steam_tenderloinmedium": "Auto (para): Polędwica (średnia)",
+          "cooking_oven_program_dish_automatic_conv_steam_topsideandtoprump": "Auto (para): Zrazowa górna i kulka",
+          "cooking_oven_program_dish_automatic_conv_steam_unstuffedchicken": "Auto (para): Kurczak (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_steam_unstuffedduck": "Auto (para): Kaczka (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_steam_unstuffedgoose": "Auto (para): Gęś (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_steam_unstuffedsmallturkey": "Auto (para): Mały indyk (bez nadzienia)",
+          "cooking_oven_program_dish_automatic_conv_steam_vienneseboiledbeef": "Auto (para): Wołowina gotowana po wiedeńsku",
+          "cooking_oven_program_dish_automatic_conv_steam_wheatbreadmultigrainwheatbreadinaloaftin": "Auto (para): Chleb pszenny/wieloziarnisty w foremce",
+          "cooking_oven_program_dish_automatic_conv_steam_wheatbreadmultigrainwheatbreadonabakingtray": "Auto (para): Chleb pszenny/wieloziarnisty na blasze",
+          "cooking_oven_program_dish_automatic_conv_steam_whitebreadinaloaftin": "Auto (para): Chleb biały w foremce",
+          "cooking_oven_program_dish_automatic_conv_steam_whitebreadonabakingtray": "Auto (para): Chleb biały na blasze",
+          "cooking_oven_program_dish_automatic_conv_steam_wholerabbit": "Auto (para): Cały królik",
+          "cooking_oven_program_dish_automatic_conv_steam_wholemealbreadonbakingtray": "Auto (para): Chleb razowy na blasze",
+          "cooking_oven_program_dish_automatic_conv_steam_wildboarroast": "Auto (para): Pieczeń z dzika",
+          "cooking_oven_program_dish_automatic_fullsteam_fishwholesteam": "Auto (pełna para): Ryba w całości",
+          "cooking_oven_program_dish_recommendation_conv_bakesavouryfreshcookedingredients": "Rekomendacja: Zapiekanka wytrawna (świeże/gotowane składniki)",
+          "cooking_oven_program_dish_recommendation_conv_bakesweetfresh": "Rekomendacja: Zapiekanka słodka (świeża)",
+          "cooking_oven_program_dish_recommendation_conv_bakedpotatoes": "Rekomendacja: Pieczone ziemniaki",
+          "cooking_oven_program_dish_recommendation_conv_bakedpotatoeson2levels": "Rekomendacja: Pieczone ziemniaki (2 poziomy)",
+          "cooking_oven_program_dish_recommendation_conv_baklava": "Rekomendacja: Baklava",
+          "cooking_oven_program_dish_recommendation_conv_biscuits": "Rekomendacja: Herbatniki",
+          "cooking_oven_program_dish_recommendation_conv_blindbakepastrybase": "Rekomendacja: Podpiekanie ciasta",
+          "cooking_oven_program_dish_recommendation_conv_boerek": "Rekomendacja: Börek",
+          "cooking_oven_program_dish_recommendation_conv_bonlessrolledshoulder": "Rekomendacja: Zwijana łopatka bez kości",
+          "cooking_oven_program_dish_recommendation_conv_breadrolls": "Rekomendacja: Bułki",
+          "cooking_oven_program_dish_recommendation_conv_breadrollsfrozen": "Rekomendacja: Bułki (mrożone)",
+          "cooking_oven_program_dish_recommendation_conv_breastofvealstuffed": "Rekomendacja: Mostek cielęcy (nadziewany)",
+          "cooking_oven_program_dish_recommendation_conv_cannelloni": "Rekomendacja: Cannelloni",
+          "cooking_oven_program_dish_recommendation_conv_chickenbreastfillet": "Rekomendacja: Filet z piersi kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_chickenbreastfilletgrill": "Rekomendacja: Filet z piersi kurczaka (grill)",
+          "cooking_oven_program_dish_recommendation_conv_chickendrumsticks": "Rekomendacja: Podudzia kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_chickengoujonsnuggets": "Rekomendacja: Goujons/Nuggets z kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_chickenparts": "Rekomendacja: Części kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_chilledlasagne": "Rekomendacja: Lazania (schłodzona)",
+          "cooking_oven_program_dish_recommendation_conv_chilledpasta": "Rekomendacja: Makaron schłodzony",
+          "cooking_oven_program_dish_recommendation_conv_chips": "Rekomendacja: Frytki",
+          "cooking_oven_program_dish_recommendation_conv_chouxpastry": "Rekomendacja: Ciasto parzone",
+          "cooking_oven_program_dish_recommendation_conv_ciabatta": "Rekomendacja: Ciabatta",
+          "cooking_oven_program_dish_recommendation_conv_croissantsdough": "Rekomendacja: Croissanty",
+          "cooking_oven_program_dish_recommendation_conv_croquettes": "Rekomendacja: Krokiety",
+          "cooking_oven_program_dish_recommendation_conv_danishpastry": "Rekomendacja: Duńskie wypieki",
+          "cooking_oven_program_dish_recommendation_conv_duckbreast": "Rekomendacja: Pierś kaczki",
+          "cooking_oven_program_dish_recommendation_conv_empanada": "Rekomendacja: Empanada",
+          "cooking_oven_program_dish_recommendation_conv_fatlessspongecake": "Rekomendacja: Biszkopt beztłuszczowy",
+          "cooking_oven_program_dish_recommendation_conv_fishfilletstew": "Rekomendacja: Filet rybny (duszony)",
+          "cooking_oven_program_dish_recommendation_conv_flatbread": "Rekomendacja: Podpłomyk",
+          "cooking_oven_program_dish_recommendation_conv_freshbreadrolls": "Rekomendacja: Świeże bułki",
+          "cooking_oven_program_dish_recommendation_conv_freshlasagne": "Rekomendacja: Świeża lazania",
+          "cooking_oven_program_dish_recommendation_conv_freshsweetbreadrolls": "Rekomendacja: Słodkie bułki",
+          "cooking_oven_program_dish_recommendation_conv_fruitcrumble": "Rekomendacja: Crumble owocowy",
+          "cooking_oven_program_dish_recommendation_conv_fruittartorcheesecakewithpastrybase": "Rekomendacja: Tarta owocowa lub sernik z ciastem",
+          "cooking_oven_program_dish_recommendation_conv_gammonjoint": "Rekomendacja: Szynka wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_goosestuffed": "Rekomendacja: Gęś (nadziewana)",
+          "cooking_oven_program_dish_recommendation_conv_halvedchicken": "Rekomendacja: Połówka kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_hashbrowns": "Rekomendacja: Hash Browns",
+          "cooking_oven_program_dish_recommendation_conv_hashbrownsgb": "Rekomendacja: Hash Browns (GB)",
+          "cooking_oven_program_dish_recommendation_conv_jamtarts": "Rekomendacja: Tartaletki z dżemem",
+          "cooking_oven_program_dish_recommendation_conv_jamtarts2levels": "Rekomendacja: Tartaletki z dżemem (2 poziomy)",
+          "cooking_oven_program_dish_recommendation_conv_knuckleofpork": "Rekomendacja: Golonka wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_lambkarree": "Rekomendacja: Karczek jagnięcy",
+          "cooking_oven_program_dish_recommendation_conv_lasagnefrozen": "Rekomendacja: Lazania (mrożona)",
+          "cooking_oven_program_dish_recommendation_conv_leavenedcake": "Rekomendacja: Ciasto drożdżowe",
+          "cooking_oven_program_dish_recommendation_conv_loinjoint": "Rekomendacja: Polędwica wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_macaroons": "Rekomendacja: Makaroniki",
+          "cooking_oven_program_dish_recommendation_conv_meringue": "Rekomendacja: Beza",
+          "cooking_oven_program_dish_recommendation_conv_minipizzas": "Rekomendacja: Mini pizze",
+          "cooking_oven_program_dish_recommendation_conv_muffins": "Rekomendacja: Muffinki",
+          "cooking_oven_program_dish_recommendation_conv_partcookedbreadrollsorbaguette": "Rekomendacja: Podpieczone bułki lub bagietki",
+          "cooking_oven_program_dish_recommendation_conv_partcookedbreadrollsorbaguettefrozen": "Rekomendacja: Podpieczone bułki lub bagietki (mrożone)",
+          "cooking_oven_program_dish_recommendation_conv_pierogi": "Rekomendacja: Pierogi",
+          "cooking_oven_program_dish_recommendation_conv_pipedcookies": "Rekomendacja: Ciasteczka z rękawa",
+          "cooking_oven_program_dish_recommendation_conv_pizzabaguettefrozen": "Rekomendacja: Pizza bagietka (mrożona)",
+          "cooking_oven_program_dish_recommendation_conv_pizzachilled": "Rekomendacja: Pizza (schłodzona)",
+          "cooking_oven_program_dish_recommendation_conv_pizzafreshonbakingtray": "Rekomendacja: Pizza (świeża, na blasze)",
+          "cooking_oven_program_dish_recommendation_conv_pizzafreshthinbaseinpizzatray": "Rekomendacja: Pizza (świeża, cienkie ciasto, na tacy)",
+          "cooking_oven_program_dish_recommendation_conv_pizzathickcrust1slicefrozen": "Rekomendacja: Pizza gruby spód 1 kawałek (mrożona)",
+          "cooking_oven_program_dish_recommendation_conv_pizzathincrust1slice": "Rekomendacja: Pizza cienki spód 1 kawałek",
+          "cooking_oven_program_dish_recommendation_conv_porkroast": "Rekomendacja: Pieczeń wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_potatogratinrawingredients4cmdeep": "Rekomendacja: Gratin ziemniaczany (surowe składniki, 4 cm)",
+          "cooking_oven_program_dish_recommendation_conv_potatopocketsfilled": "Rekomendacja: Nadziewane kieszonki ziemniaczane",
+          "cooking_oven_program_dish_recommendation_conv_potatowedges": "Rekomendacja: Ćwiartki ziemniaków",
+          "cooking_oven_program_dish_recommendation_conv_pretzelsdough": "Rekomendacja: Precle",
+          "cooking_oven_program_dish_recommendation_conv_puffpastry": "Rekomendacja: Ciasto francuskie",
+          "cooking_oven_program_dish_recommendation_conv_quichetart": "Rekomendacja: Quiche/Tarta",
+          "cooking_oven_program_dish_recommendation_conv_richfruitcake": "Rekomendacja: Ciasto owocowe",
+          "cooking_oven_program_dish_recommendation_conv_roasthalvedpotatoes": "Rekomendacja: Pieczone połówki ziemniaków",
+          "cooking_oven_program_dish_recommendation_conv_roastwholefish": "Rekomendacja: Pieczona cała ryba",
+          "cooking_oven_program_dish_recommendation_conv_roastbeefmedium": "Rekomendacja: Rostbef (średni)",
+          "cooking_oven_program_dish_recommendation_conv_rolledturkeyjoint": "Rekomendacja: Zwijana pieczeń z indyka",
+          "cooking_oven_program_dish_recommendation_conv_saddleofveal": "Rekomendacja: Siodło cielęce",
+          "cooking_oven_program_dish_recommendation_conv_saddleofvenisononthebone": "Rekomendacja: Siodło jelenia z kością",
+          "cooking_oven_program_dish_recommendation_conv_savarinplaitedloaf": "Rekomendacja: Savarin/Warkocz",
+          "cooking_oven_program_dish_recommendation_conv_scones": "Rekomendacja: Scones",
+          "cooking_oven_program_dish_recommendation_conv_scones2levels": "Rekomendacja: Scones (2 poziomy)",
+          "cooking_oven_program_dish_recommendation_conv_shortcrustpastrydishes": "Rekomendacja: Dania z kruchego ciasta",
+          "cooking_oven_program_dish_recommendation_conv_shortcrustpastryflanbase": "Rekomendacja: Spód tarty z kruchego ciasta",
+          "cooking_oven_program_dish_recommendation_conv_shortcrustpastrywithmoisttopping": "Rekomendacja: Kruche ciasto z wilgotnym nadzieniem",
+          "cooking_oven_program_dish_recommendation_conv_shoulderonthebone": "Rekomendacja: Łopatka z kością",
+          "cooking_oven_program_dish_recommendation_conv_simplespongecake": "Rekomendacja: Proste ciasto biszkoptowe",
+          "cooking_oven_program_dish_recommendation_conv_slicesofmeatinsauceegschnitzelstew": "Rekomendacja: Plastry mięsa w sosie (sznycel/gulasz)",
+          "cooking_oven_program_dish_recommendation_conv_smallcakes": "Rekomendacja: Małe ciastka",
+          "cooking_oven_program_dish_recommendation_conv_smallcakes2levels": "Rekomendacja: Małe ciastka (2 poziomy)",
+          "cooking_oven_program_dish_recommendation_conv_soufflesinindividualmolds": "Rekomendacja: Soufflé w foremkach",
+          "cooking_oven_program_dish_recommendation_conv_spongecakewithdrytopping": "Rekomendacja: Biszkopt z suchym nadzieniem",
+          "cooking_oven_program_dish_recommendation_conv_spongecakewithmoisttopping": "Rekomendacja: Biszkopt z wilgotnym nadzieniem",
+          "cooking_oven_program_dish_recommendation_conv_spongeflanbase": "Rekomendacja: Spód biszkoptowy",
+          "cooking_oven_program_dish_recommendation_conv_spongefruitflan": "Rekomendacja: Biszkopt z owocami",
+          "cooking_oven_program_dish_recommendation_conv_squidringsbreaded": "Rekomendacja: Panierowane pierścienie kalmara",
+          "cooking_oven_program_dish_recommendation_conv_stuffedchicken": "Rekomendacja: Nadziewany kurczak",
+          "cooking_oven_program_dish_recommendation_conv_stuffedduck": "Rekomendacja: Nadziewana kaczka",
+          "cooking_oven_program_dish_recommendation_conv_stuffedvegetables": "Rekomendacja: Nadziewane warzywa",
+          "cooking_oven_program_dish_recommendation_conv_sweetstrudel": "Rekomendacja: Słodki strudel",
+          "cooking_oven_program_dish_recommendation_conv_swissroll": "Rekomendacja: Rolada biszkoptowa",
+          "cooking_oven_program_dish_recommendation_conv_swissrollgb": "Rekomendacja: Rolada biszkoptowa (GB)",
+          "cooking_oven_program_dish_recommendation_conv_tart": "Rekomendacja: Tarta",
+          "cooking_oven_program_dish_recommendation_conv_tarteflambee": "Rekomendacja: Tarte Flambée",
+          "cooking_oven_program_dish_recommendation_conv_tenderloinmedium": "Rekomendacja: Polędwica (średnia)",
+          "cooking_oven_program_dish_recommendation_conv_topsideandtoprump": "Rekomendacja: Zrazowa górna i kulka",
+          "cooking_oven_program_dish_recommendation_conv_turkeycrownbritishstyle": "Rekomendacja: Korona indyka (brytyjski styl)",
+          "cooking_oven_program_dish_recommendation_conv_vegetablesaugratin": "Rekomendacja: Warzywa au gratin",
+          "cooking_oven_program_dish_recommendation_conv_victoriaspongecake": "Rekomendacja: Biszkopt Victoria",
+          "cooking_oven_program_dish_recommendation_conv_victoriaspongecake2levels": "Rekomendacja: Biszkopt Victoria (2 poziomy)",
+          "cooking_oven_program_dish_recommendation_conv_volauvents": "Rekomendacja: Vol-au-Vents",
+          "cooking_oven_program_dish_recommendation_conv_wheatbreadmultigrainwheatbreadinaloaftin": "Rekomendacja: Chleb pszenny/wieloziarnisty w foremce",
+          "cooking_oven_program_dish_recommendation_conv_wheatbreadmultigrainwheatbreadonabakingtray": "Rekomendacja: Chleb pszenny/wieloziarnisty na blasze",
+          "cooking_oven_program_dish_recommendation_conv_whitebread": "Rekomendacja: Chleb biały",
+          "cooking_oven_program_dish_recommendation_conv_whitebreadinaloaftin": "Rekomendacja: Chleb biały w foremce",
+          "cooking_oven_program_dish_recommendation_conv_whitebreadonabakingtray": "Rekomendacja: Chleb biały na blasze",
+          "cooking_oven_program_dish_recommendation_conv_wholebakedpotatoes": "Rekomendacja: Pieczone całe ziemniaki",
+          "cooking_oven_program_dish_recommendation_conv_wholechicken": "Rekomendacja: Cały kurczak",
+          "cooking_oven_program_dish_recommendation_conv_yeastcakewithdrytopping": "Rekomendacja: Ciasto drożdżowe z suchym nadzieniem",
+          "cooking_oven_program_dish_recommendation_conv_yeastcakewithmoisttopping": "Rekomendacja: Ciasto drożdżowe z wilgotnym nadzieniem",
+          "cooking_oven_program_dish_recommendation_conv_yeastleavenedbundtcake": "Rekomendacja: Babka drożdżowa",
+          "cooking_oven_program_dish_recommendation_conv_yogurtinglassjars": "Rekomendacja: Jogurt w słoiczkach",
+          "cooking_oven_program_dish_recommendation_conv_yorkshirepudding": "Rekomendacja: Yorkshire Pudding",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_bonelesslegoflambmedium": "Sonda mięsna: Udziec jagnięcy bez kości (średni)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_bonelesslegoflambwelldone": "Sonda mięsna: Udziec jagnięcy bez kości (wypieczony)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_bonelessporkneckjoint": "Sonda mięsna: Karkówka bez kości",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_breastofvealstuffed": "Sonda mięsna: Mostek cielęcy (nadziewany)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_chickenbreastfillet": "Sonda mięsna: Filet z piersi kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_duckbreast": "Sonda mięsna: Pierś kaczki",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_goosebreast": "Sonda mięsna: Pierś gęsi",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_gooselegs": "Sonda mięsna: Udka gęsi",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_jointofporkwithcracklingegshoulder": "Sonda mięsna: Łopatka wieprzowa ze skórką",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_jointofveallean": "Sonda mięsna: Cielęcina (chuda)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_jointofvealmarbled": "Sonda mięsna: Cielęcina (marmurkowa)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_knuckleofpork": "Sonda mięsna: Golonka wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_knuckleofveal": "Sonda mięsna: Gicz cielęca",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_legoflambonthebonewelldone": "Sonda mięsna: Udziec jagnięcy z kością (wypieczony)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_loinjoint": "Sonda mięsna: Polędwica wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_meatloafmadefromfreshmincedmeat": "Sonda mięsna: Pieczeń rzymska ze świeżego mięsa mielonego",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_poulardunstuffed": "Sonda mięsna: Pularada (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_roastjoint": "Sonda mięsna: Pieczona pieczeń",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_roastporkchoponthebone": "Sonda mięsna: Kotlet wieprzowy z kością",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_roastporkloin": "Sonda mięsna: Pieczeń wieprzowa (schab)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_roastwholefish": "Sonda mięsna: Pieczona cała ryba",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_rolledporkjoint": "Sonda mięsna: Zwijana pieczeń wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_rolledturkeyjoint": "Sonda mięsna: Zwijana pieczeń z indyka",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_saddleofveal": "Sonda mięsna: Siodło cielęce",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_sirloinmedium": "Sonda mięsna: Rostbef (średni)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_sirloinrare": "Sonda mięsna: Rostbef (krwisty)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_stuffedchicken": "Sonda mięsna: Nadziewany kurczak",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_tenderloinmedium": "Sonda mięsna: Polędwica (średnia)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_turkeybreast": "Sonda mięsna: Pierś indyka",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_unstuffedchicken": "Sonda mięsna: Kurczak (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_meatprobe_unstuffedsmallturkey": "Sonda mięsna: Mały indyk (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_steam_bakesavouryfreshcookedingredients": "Rekomendacja (para): Zapiekanka wytrawna (świeże/gotowane składniki)",
+          "cooking_oven_program_dish_recommendation_conv_steam_bakesweetfresh": "Rekomendacja (para): Zapiekanka słodka (świeża)",
+          "cooking_oven_program_dish_recommendation_conv_steam_baklava": "Rekomendacja (para): Baklava",
+          "cooking_oven_program_dish_recommendation_conv_steam_cannelloni": "Rekomendacja (para): Cannelloni",
+          "cooking_oven_program_dish_recommendation_conv_steam_chouxpastry": "Rekomendacja (para): Ciasto parzone",
+          "cooking_oven_program_dish_recommendation_conv_steam_ciabatta": "Rekomendacja (para): Ciabatta",
+          "cooking_oven_program_dish_recommendation_conv_steam_croissantsdough": "Rekomendacja (para): Croissanty",
+          "cooking_oven_program_dish_recommendation_conv_steam_danishpastry": "Rekomendacja (para): Duńskie wypieki",
+          "cooking_oven_program_dish_recommendation_conv_steam_duckbreast": "Rekomendacja (para): Pierś kaczki",
+          "cooking_oven_program_dish_recommendation_conv_steam_filletofpork": "Rekomendacja (para): Polędwiczka wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_steam_freshbreadrolls": "Rekomendacja (para): Świeże bułki",
+          "cooking_oven_program_dish_recommendation_conv_steam_freshlasagne": "Rekomendacja (para): Świeża lazania",
+          "cooking_oven_program_dish_recommendation_conv_steam_freshsweetbreadrolls": "Rekomendacja (para): Słodkie bułki",
+          "cooking_oven_program_dish_recommendation_conv_steam_gooselegs": "Rekomendacja (para): Udka gęsi",
+          "cooking_oven_program_dish_recommendation_conv_steam_goosestuffed": "Rekomendacja (para): Gęś (nadziewana)",
+          "cooking_oven_program_dish_recommendation_conv_steam_halvedchicken": "Rekomendacja (para): Połówka kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_steam_lasagnefrozen": "Rekomendacja (para): Lazania (mrożona)",
+          "cooking_oven_program_dish_recommendation_conv_steam_leavenedcake": "Rekomendacja (para): Ciasto drożdżowe",
+          "cooking_oven_program_dish_recommendation_conv_steam_partcookedbreadrollsorbaguette": "Rekomendacja (para): Podpieczone bułki lub bagietki",
+          "cooking_oven_program_dish_recommendation_conv_steam_partcookedrollsorbaguettefrozen": "Rekomendacja (para): Podpieczone bułki lub bagietki (mrożone)",
+          "cooking_oven_program_dish_recommendation_conv_steam_potatogratinrawingredients4cmdeep": "Rekomendacja (para): Gratin ziemniaczany (surowe składniki, 4 cm)",
+          "cooking_oven_program_dish_recommendation_conv_steam_pretzelsdough": "Rekomendacja (para): Precle",
+          "cooking_oven_program_dish_recommendation_conv_steam_puffpastry": "Rekomendacja (para): Ciasto francuskie",
+          "cooking_oven_program_dish_recommendation_conv_steam_rolledturkeyjoint": "Rekomendacja (para): Zwijana pieczeń z indyka",
+          "cooking_oven_program_dish_recommendation_conv_steam_saddleofveal": "Rekomendacja (para): Siodło cielęce",
+          "cooking_oven_program_dish_recommendation_conv_steam_savarinplaitedloaf": "Rekomendacja (para): Savarin/Warkocz",
+          "cooking_oven_program_dish_recommendation_conv_steam_stuffedchicken": "Rekomendacja (para): Nadziewany kurczak",
+          "cooking_oven_program_dish_recommendation_conv_steam_stuffedduck": "Rekomendacja (para): Nadziewana kaczka",
+          "cooking_oven_program_dish_recommendation_conv_steam_sweetstrudel": "Rekomendacja (para): Słodki strudel",
+          "cooking_oven_program_dish_recommendation_conv_steam_turkeybreast": "Rekomendacja (para): Pierś indyka",
+          "cooking_oven_program_dish_recommendation_conv_steam_turkeythigh": "Rekomendacja (para): Udziec z indyka",
+          "cooking_oven_program_dish_recommendation_conv_steam_whitebread": "Rekomendacja (para): Chleb biały",
+          "cooking_oven_program_dish_recommendation_conv_steam_yeastleavenedbundtcake": "Rekomendacja (para): Babka drożdżowa",
+          "cooking_oven_program_dish_recommendation_conv_steam_yeaststollen": "Rekomendacja (para): Strucla drożdżowa",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_bonelesslegoflambmedium": "Sonda mięsna (para): Udziec jagnięcy bez kości (średni)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_bonelesslegoflambwelldone": "Sonda mięsna (para): Udziec jagnięcy bez kości (wypieczony)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_bonelessporkneckjoint": "Sonda mięsna (para): Karkówka bez kości",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_breastofvealstuffed": "Sonda mięsna (para): Mostek cielęcy (nadziewany)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_duckbreast": "Sonda mięsna (para): Pierś kaczki",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_filletofpork": "Sonda mięsna (para): Polędwiczka wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_gooselegs": "Sonda mięsna (para): Udka gęsi",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_halvedchicken": "Sonda mięsna (para): Połówka kurczaka",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_jointofveallean": "Sonda mięsna (para): Cielęcina (chuda)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_jointofvealmarbled": "Sonda mięsna (para): Cielęcina (marmurkowa)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_knuckleofveal": "Sonda mięsna (para): Gicz cielęca",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_legoflambonthebonewelldone": "Sonda mięsna (para): Udziec jagnięcy z kością (wypieczony)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_meatloafmadefromfreshmincedmeat": "Sonda mięsna (para): Pieczeń rzymska ze świeżego mięsa mielonego",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_poulardunstuffed": "Sonda mięsna (para): Pularada (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_roastporkchoponthebone": "Sonda mięsna (para): Kotlet wieprzowy z kością",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_roastporkloin": "Sonda mięsna (para): Pieczeń wieprzowa (schab)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_rolledporkjoint": "Sonda mięsna (para): Zwijana pieczeń wieprzowa",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_rolledturkeyjoint": "Sonda mięsna (para): Zwijana pieczeń z indyka",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_saddleofveal": "Sonda mięsna (para): Siodło cielęce",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_sirloinmedium": "Sonda mięsna (para): Rostbef (średni)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_sirloinrare": "Sonda mięsna (para): Rostbef (krwisty)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_smokedporkonthebone": "Sonda mięsna (para): Wędzona wieprzowina z kością",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_tenderloinmedium": "Sonda mięsna (para): Polędwica (średnia)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_turkeybreast": "Sonda mięsna (para): Pierś indyka",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_turkeythigh": "Sonda mięsna (para): Udziec z indyka",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_unstuffedchicken": "Sonda mięsna (para): Kurczak (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_unstuffedduck": "Sonda mięsna (para): Kaczka (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_unstuffedgoose": "Sonda mięsna (para): Gęś (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_conv_steam_meatprobe_unstuffedsmallturkey": "Sonda mięsna (para): Mały indyk (bez nadzienia)",
+          "cooking_oven_program_dish_recommendation_fullsteam_applesinslices5mm": "Pełna para: Jabłka w plastrach 5mm",
+          "cooking_oven_program_dish_recommendation_fullsteam_basmatirice": "Pełna para: Ryż basmati",
+          "cooking_oven_program_dish_recommendation_fullsteam_beans": "Pełna para: Fasola",
+          "cooking_oven_program_dish_recommendation_fullsteam_beetrootwholesteam": "Pełna para: Burak w całości",
+          "cooking_oven_program_dish_recommendation_fullsteam_bluemussels": "Pełna para: Małże",
+          "cooking_oven_program_dish_recommendation_fullsteam_boiledpotatoes": "Pełna para: Ziemniaki gotowane",
+          "cooking_oven_program_dish_recommendation_fullsteam_boiledpotatoeswskinlarge": "Pełna para: Ziemniaki gotowane w mundurkach (duże)",
+          "cooking_oven_program_dish_recommendation_fullsteam_boiledpotatoeswskinmedium": "Pełna para: Ziemniaki gotowane w mundurkach (średnie)",
+          "cooking_oven_program_dish_recommendation_fullsteam_boiledpotatoeswskinsmall": "Pełna para: Ziemniaki gotowane w mundurkach (małe)",
+          "cooking_oven_program_dish_recommendation_fullsteam_boiledsausages": "Pełna para: Parówki gotowane",
+          "cooking_oven_program_dish_recommendation_fullsteam_broccoli": "Pełna para: Brokuły",
+          "cooking_oven_program_dish_recommendation_fullsteam_brownrice": "Pełna para: Ryż brązowy",
+          "cooking_oven_program_dish_recommendation_fullsteam_brusselssprouts": "Pełna para: Brukselka",
+          "cooking_oven_program_dish_recommendation_fullsteam_canellinibeanspresoftened": "Pełna para: Fasola Cannellini (wstępnie namoczona)",
+          "cooking_oven_program_dish_recommendation_fullsteam_carrots": "Pełna para: Marchewka",
+          "cooking_oven_program_dish_recommendation_fullsteam_cauliflower": "Pełna para: Kalafior",
+          "cooking_oven_program_dish_recommendation_fullsteam_cauliflowerfloretssteam": "Pełna para: Różyczki kalafiora",
+          "cooking_oven_program_dish_recommendation_fullsteam_chickenbreastfilletsteam": "Pełna para: Filet z piersi kurczaka",
+          "cooking_oven_program_dish_recommendation_fullsteam_cod": "Pełna para: Dorsz",
+          "cooking_oven_program_dish_recommendation_fullsteam_codcutlet": "Pełna para: Kotlet z dorsza",
+          "cooking_oven_program_dish_recommendation_fullsteam_couscous": "Pełna para: Kuskus",
+          "cooking_oven_program_dish_recommendation_fullsteam_cremecaramel": "Pełna para: Crème Caramel",
+          "cooking_oven_program_dish_recommendation_fullsteam_defrostberries": "Pełna para: Rozmrażanie owoców jagodowych",
+          "cooking_oven_program_dish_recommendation_fullsteam_defrostinblockfrozenvegetables": "Pełna para: Rozmrażanie warzyw mrożonych w bloku",
+          "cooking_oven_program_dish_recommendation_fullsteam_defrostloosevegetables": "Pełna para: Rozmrażanie warzyw luzem",
+          "cooking_oven_program_dish_recommendation_fullsteam_dumplings": "Pełna para: Pierogi/Kluski",
+          "cooking_oven_program_dish_recommendation_fullsteam_fishfilletfreshsteam": "Pełna para: Filet rybny (świeży)",
+          "cooking_oven_program_dish_recommendation_fullsteam_fishterrine": "Pełna para: Terrina rybna",
+          "cooking_oven_program_dish_recommendation_fullsteam_frozenfishfillet": "Pełna para: Filet rybny (mrożony)",
+          "cooking_oven_program_dish_recommendation_fullsteam_fruitcompote": "Pełna para: Kompot owocowy",
+          "cooking_oven_program_dish_recommendation_fullsteam_greenasparagus": "Pełna para: Zielone szparagi",
+          "cooking_oven_program_dish_recommendation_fullsteam_greenbeanssteam": "Pełna para: Fasolka szparagowa",
+          "cooking_oven_program_dish_recommendation_fullsteam_halibut": "Pełna para: Halibut",
+          "cooking_oven_program_dish_recommendation_fullsteam_halibutcutlet": "Pełna para: Kotlet z halibuta",
+          "cooking_oven_program_dish_recommendation_fullsteam_hardboiledeggs": "Pełna para: Jajka na twardo",
+          "cooking_oven_program_dish_recommendation_fullsteam_lentils": "Pełna para: Soczewica",
+          "cooking_oven_program_dish_recommendation_fullsteam_longgrainrice": "Pełna para: Ryż długoziarnisty",
+          "cooking_oven_program_dish_recommendation_fullsteam_meatprobe_chickenbreastfilletsteam": "Sonda mięsna (pełna para): Filet z piersi kurczaka",
+          "cooking_oven_program_dish_recommendation_fullsteam_meatprobe_fishwholesteam": "Sonda mięsna (pełna para): Ryba w całości",
+          "cooking_oven_program_dish_recommendation_fullsteam_millet": "Pełna para: Kasza jaglana",
+          "cooking_oven_program_dish_recommendation_fullsteam_mixedvegetablesfrozen": "Pełna para: Warzywa mieszane (mrożone)",
+          "cooking_oven_program_dish_recommendation_fullsteam_monkfish": "Pełna para: Żabnica",
+          "cooking_oven_program_dish_recommendation_fullsteam_parboiledrice": "Pełna para: Ryż parboiled",
+          "cooking_oven_program_dish_recommendation_fullsteam_pearlbarley": "Pełna para: Kasza perłowa",
+          "cooking_oven_program_dish_recommendation_fullsteam_peas": "Pełna para: Groszek",
+          "cooking_oven_program_dish_recommendation_fullsteam_pineappleinslices1to2cm": "Pełna para: Ananas w plastrach 1-2cm",
+          "cooking_oven_program_dish_recommendation_fullsteam_pipfruits": "Pełna para: Owoce ziarnkowe",
+          "cooking_oven_program_dish_recommendation_fullsteam_polenta": "Pełna para: Polenta",
+          "cooking_oven_program_dish_recommendation_fullsteam_prawns": "Pełna para: Krewetki",
+          "cooking_oven_program_dish_recommendation_fullsteam_pumpkin": "Pełna para: Dynia",
+          "cooking_oven_program_dish_recommendation_fullsteam_raspberries": "Pełna para: Maliny",
+          "cooking_oven_program_dish_recommendation_fullsteam_redcurrants": "Pełna para: Czerwone porzeczki",
+          "cooking_oven_program_dish_recommendation_fullsteam_ricepudding": "Pełna para: Ryż na mleku",
+          "cooking_oven_program_dish_recommendation_fullsteam_risotto": "Pełna para: Risotto",
+          "cooking_oven_program_dish_recommendation_fullsteam_royale": "Pełna para: Royale",
+          "cooking_oven_program_dish_recommendation_fullsteam_salmon": "Pełna para: Łosoś",
+          "cooking_oven_program_dish_recommendation_fullsteam_salmoncutlet": "Pełna para: Kotlet z łososia",
+          "cooking_oven_program_dish_recommendation_fullsteam_salmonfillet": "Pełna para: Filet z łososia",
+          "cooking_oven_program_dish_recommendation_fullsteam_seabass": "Pełna para: Okoń morski",
+          "cooking_oven_program_dish_recommendation_fullsteam_semolinadumplings": "Pełna para: Kluski manne",
+          "cooking_oven_program_dish_recommendation_fullsteam_softboiledeggs": "Pełna para: Jajka na miękko",
+          "cooking_oven_program_dish_recommendation_fullsteam_softwheatwhole": "Pełna para: Pszenica zwyczajna (ziarno)",
+          "cooking_oven_program_dish_recommendation_fullsteam_solerollsstuffed": "Pełna para: Rulony z soli (nadziewane)",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamartichokes": "Pełna para: Karczochy",
+          "cooking_oven_program_dish_recommendation_fullsteam_steambroccoliflorets": "Pełna para: Różyczki brokuła",
+          "cooking_oven_program_dish_recommendation_fullsteam_steambrusselssprouts": "Pełna para: Brukselka",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamgreenasparagus": "Pełna para: Zielone szparagi",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamleeksinrings": "Pełna para: Pory w krążkach",
+          "cooking_oven_program_dish_recommendation_fullsteam_steammangetout": "Pełna para: Groszek cukrowy",
+          "cooking_oven_program_dish_recommendation_fullsteam_steampeas": "Pełna para: Groszek",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamshreddedredcabbage": "Pełna para: Czerwona kapusta szatkowana",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamshreddedswisschard": "Pełna para: Boćwina szatkowana",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamshreddedwhitecabbage": "Pełna para: Biała kapusta szatkowana",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamslicedcarrots": "Pełna para: Marchewka w plastrach",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamslicedcourgettes": "Pełna para: Cukinia w plastrach",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamslicedfennel": "Pełna para: Koper włoski w plastrach",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamslicedkohlrabi": "Pełna para: Kalarepa w plastrach",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamspinach": "Pełna para: Szpinak",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamvegetableflan": "Pełna para: Tarta warzywna",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamwhiteasparagus": "Pełna para: Szparagi białe",
+          "cooking_oven_program_dish_recommendation_fullsteam_steamwholecauliflower": "Pełna para: Kalafior w całości",
+          "cooking_oven_program_dish_recommendation_fullsteam_sterilisingbottles": "Pełna para: Sterylizacja butelek",
+          "cooking_oven_program_dish_recommendation_fullsteam_stonefruits": "Pełna para: Owoce pestkowe",
+          "cooking_oven_program_dish_recommendation_fullsteam_tomatoes": "Pełna para: Pomidory",
+          "cooking_oven_program_dish_recommendation_fullsteam_trout": "Pełna para: Pstrąg",
+          "cooking_oven_program_dish_recommendation_fullsteam_turbot": "Pełna para: Turbot",
+          "cooking_oven_program_dish_recommendation_fullsteam_turbotcutlet": "Pełna para: Kotlet z turbota",
+          "cooking_oven_program_dish_recommendation_fullsteam_unripespeltgraincoarseground": "Pełna para: Niedojrzałe ziarno orkiszu, grubo mielone",
+          "cooking_oven_program_dish_recommendation_fullsteam_vanillasauce": "Pełna para: Sos waniliowy",
+          "cooking_oven_program_dish_recommendation_fullsteam_vegetables": "Pełna para: Warzywa",
+          "cooking_oven_program_dish_recommendation_fullsteam_wholewheat": "Pełna para: Pszenica pełnoziarnista",
+          "cooking_oven_program_dish_recommendation_fullsteam_yeastdumplings": "Pełna para: Knedle drożdżowe",
+          "cooking_oven_program_dish_sousvide_fullsteam_beeforvealfiletmedallions3to4cm": "Sous Vide: Medaliony z filetu wołowego lub cielęcego 3-4cm",
+          "cooking_oven_program_dish_sousvide_fullsteam_beeforvealsteak": "Sous Vide: Stek wołowy lub cielęcy",
+          "cooking_oven_program_dish_sousvide_fullsteam_chickenbreastfillet": "Sous Vide: Filet z piersi kurczaka",
+          "cooking_oven_program_dish_sousvide_fullsteam_duckbreast": "Sous Vide: Pierś kaczki",
+          "cooking_oven_program_dish_sousvide_fullsteam_fishfillet": "Sous Vide: Filet rybny",
+          "cooking_oven_program_dish_sousvide_fullsteam_porkfiletmedaillions4to5cm": "Sous Vide: Medaliony z polędwicy wieprzowej 4-5cm",
+          "cooking_oven_program_dish_sousvide_fullsteam_prawns": "Sous Vide: Krewetki",
+          "cooking_oven_program_dish_sousvide_fullsteam_saddleoflamb": "Sous Vide: Comber jagnięcy",
+          "cooking_oven_program_dish_sousvide_fullsteam_scallops": "Sous Vide: Przegrzebki",
+          "cooking_oven_program_steammodes_defrosting": "Para: Rozmrażanie",
+          "cooking_oven_program_steammodes_doughproving": "Para: Wyrastanie ciasta",
+          "cooking_oven_program_steammodes_reheat": "Para: Podgrzewanie",
+          "cooking_oven_program_steammodes_sousvide": "Para: Sous Vide",
+          "cooking_oven_program_steammodes_steam": "Para",
+          "cooking_oven_program_subsequentmode_continuecooking": "Następny tryb: Kontynuuj gotowanie",
+          "cooking_oven_program_subsequentmode_drying": "Następny tryb: Suszenie",
+          "cooking_oven_program_subsequentmode_keepwarm": "Następny tryb: Podtrzymanie ciepła",
+          "cooking_oven_program_subsequentmode_leavetorest": "Następny tryb: Zostaw do odpoczynku",
+          "cooking_oven_program_subsequentmode_startbaking": "Następny tryb: Rozpocznij pieczenie",
+          "cooking_common_program_hood_automatic": "Automatyczny",
+          "cooking_common_program_hood_delayedshutoff": "Wyłączenie z opóźnieniem",
+          "cooking_common_program_hood_venting": "Wentylacja",
+          "laundrycare_washer_program_automatic30_auto30_auto30": "Pranie – automatyczne delikatne/30",
+          "laundrycare_washer_program_auto60": "Pranie – automatyczne 60",
+          "laundrycare_washer_program_automatic4060_auto40_auto40": "Pranie – automatyczne 40-60",
+          "laundrycare_washer_program_cotton_cotton_cotton": "Pranie – bawełna",
+          "laundrycare_washer_program_cotton": "Pranie – bawełna",
+          "laundrycare_washer_program_darkwash_darkwash_darkwash": "Pranie – ciemne",
+          "laundrycare_washer_program_darkwash_curtains_curtains": "Pranie – zasłony",
+          "laundrycare_washer_program_delicatessilk_delicatessilk_delicatessilk": "Pranie – delikatne/jedwab",
+          "laundrycare_washer_program_delicatessilk_delicatessilk_delicatessilkmp": "Pranie – Ochrona przed mikroplastikiem",
+          "laundrycare_washer_program_downduvet_down_down": "Pranie – puch",
+          "laundrycare_washer_program_drumclean_drumclean_drumclean": "Czyszczenie bębna (stare)",
+          "laundrycare_washer_program_drumclean_drumclean70_drumclean70": "Czyszczenie bębna",
+          "laundrycare_washer_program_easycare_easycare_easycare": "Pranie – łatwa pielęgnacja",
+          "laundrycare_washer_program_labeleu19_labeleu19_eco4060": "Pranie – eco 40-60",
+          "laundrycare_washer_program_mix_mix_mix": "Mix szybki",
+          "laundrycare_washer_program_outdoor_outdoor_outdoor": "Pranie – outdoor",
+          "laundrycare_washer_program_powerspeed59_powerspeed59_powerspeed59": "PowerSpeed 59'",
+          "laundrycare_washer_program_rinse_rinse_rinse": "Płukanie",
+          "laundrycare_washer_program_sensitive_sensitive_sensitive": "Pranie – sensitive",
+          "laundrycare_washer_program_shirtsblouses_shirtsblouses_shirtsblouses": "Pranie – koszule/bluzki",
+          "laundrycare_washer_program_shirtsblouses_sportfitness_sportfitness": "Pranie – odzież sportowa",
+          "laundrycare_washer_program_spin_spin_spindrain": "Wirowanie/odpływ",
+          "laundrycare_washer_program_steaming_steaming_steaming": "Para/Ułatwienie prasowania",
+          "laundrycare_washer_program_super153045_super1530_super1530": "Pranie – super krótki 15 min/30 min",
+          "laundrycare_washer_program_towels_towels_towels": "Ręczniki",
+          "laundrycare_washer_program_wool_wool_wool": "Pranie – wełna",
+          "laundrycare_washer_program_sportfitness": "Pranie – odzież sportowa",
+          "laundrycare_common_program_juststart": "Just start",
+          "laundrycare_dryer_program_blankets": "Suszenie – odzież puchowa",
+          "laundrycare_dryer_program_businessshirts": "Koszule",
+          "laundrycare_dryer_program_cotton": "Suszenie – bawełna",
+          "laundrycare_dryer_program_dessous": "Suszenie – bielizna",
+          "laundrycare_dryer_program_hygiene": "Suszenie – higieniczne",
+          "laundrycare_dryer_program_inbasket": "Suszenie – wełna w koszyku",
+          "laundrycare_dryer_program_mix": "Suszenie – mieszane",
+          "laundrycare_dryer_program_outdoor": "Suszenie – outdoor",
+          "laundrycare_dryer_program_pillow": "Suszenie – kołdra",
+          "laundrycare_dryer_program_super40": "Suszenie – ekspresowe 40 min",
+          "laundrycare_dryer_program_synthetic": "Suszenie – łatwa pielęgnacja",
+          "laundrycare_dryer_program_timecold": "Program czasowy – zimne",
+          "laundrycare_dryer_program_timewarm": "Program czasowy – ciepłe",
+          "laundrycare_dryer_program_towels": "Suszenie – ręczniki",
+          "laundrycare_dryer_program_shirtsblouses_sportfitness": "Suszenie – odzież sportowa",
+          "laundrycare_washerdryer_program_towels_towels": "Pranie i suszenie – ręczniki",
+          "laundrycare_washerdryer_program_cotton_cotton": "Pranie i suszenie – bawełna",
+          "laundrycare_washerdryer_program_mix_mix": "Pranie i suszenie – mieszane",
+          "laundrycare_washerdryer_program_wool_wool": "Pranie i suszenie – wełna",
+          "laundrycare_washerdryer_program_sportfitness_sportfitness": "Pranie i suszenie – odzież sportowa",
+          "laundrycare_washerdryer_program_washanddry_60": "Pranie i suszenie – 60'",
+          "laundrycare_washerdryer_program_downduvet_down": "Pranie i suszenie – puch",
+          "laundrycare_washerdryer_program_labeleu19_labeleu19_eco4060": "Pranie i suszenie – eco 40-60",
+          "laundrycare_washerdryer_program_cotton_cotton_cotton": "Pranie i suszenie – bawełna",
+          "laundrycare_washerdryer_program_mix_hhmix_hhmix": "Pranie i suszenie – szybkie mieszane",
+          "laundrycare_washerdryer_program_easycare_hhsynthetics_hhsynthetics": "Pranie i suszenie – łatwe w pielęgnacji",
+          "laundrycare_washerdryer_program_delicatessilk_delicatessilk_delicatessilk": "Pranie i suszenie – delikatne/jedwab",
+          "laundrycare_washerdryer_program_wool_wool_wool": "Pranie i suszenie – wełna",
+          "laundrycare_washerdryer_program_spin_spin_spindrain": "Wirowanie/odpływ",
+          "laundrycare_washerdryer_program_rinse_rinse_rinse": "Płukanie",
+          "laundrycare_washerdryer_program_sportfitness_sportfitness_sportfitness": "Pranie i suszenie – odzież sportowa",
+          "laundrycare_washerdryer_program_automatic4060_auto40_auto40": "Pranie i suszenie – automatyczne 40°C",
+          "laundrycare_washer_program_cotton_colour": "Bawełna kolorowa",
+          "laundrycare_washer_program_cotton_eco4060": "Bawełna eco 40-60",
+          "laundrycare_washer_program_delicatessilk": "Delikatne/jedwab",
+          "laundrycare_washer_program_downduvet_duvet": "Puch/kołdra",
+          "laundrycare_washer_program_easycare": "Łatwa pielęgnacja",
+          "laundrycare_washer_program_mix": "Mieszane",
+          "laundrycare_washer_program_rinse": "Płukanie",
+          "laundrycare_washer_program_sensitive": "Sensitive",
+          "laundrycare_washer_program_spin_spindrain": "Wirowanie/odpływ",
+          "laundrycare_washer_program_super153045_super1530": "Super 15/30",
+          "laundrycare_washer_program_wool": "Wełna",
+          "laundrycare_washer_program_easycare_antistainlight_blood": "Łatwa pielęgnacja – AntiStain (krew)",
+          "laundrycare_washer_program_easycare_antistainlight_butteroil": "Łatwa pielęgnacja – AntiStain (masło/olej)",
+          "laundrycare_washer_program_easycare_antistainlight_cosmetics": "Łatwa pielęgnacja – AntiStain (kosmetyki)",
+          "laundrycare_washer_program_easycare_antistainlight_tea": "Łatwa pielęgnacja – AntiStain (herbata)",
+          "consumerproducts_coffeemaker_program_beverage_caffegrande": "Caffè Grande",
+          "consumerproducts_coffeemaker_program_beverage_caffelatte": "Caffè Latte",
+          "consumerproducts_coffeemaker_program_beverage_cappuccino": "Cappuccino",
+          "consumerproducts_coffeemaker_program_beverage_coffee": "Kawa",
+          "consumerproducts_coffeemaker_program_beverage_espresso": "Espresso",
+          "consumerproducts_coffeemaker_program_beverage_espressodoppio": "Espresso Doppio",
+          "consumerproducts_coffeemaker_program_beverage_espressomacchiato": "Espresso Macchiato",
+          "consumerproducts_coffeemaker_program_beverage_hotwater": "Gorąca woda",
+          "consumerproducts_coffeemaker_program_beverage_lattemacchiato": "Latte Macchiato",
+          "consumerproducts_coffeemaker_program_beverage_milkfroth": "Spienione mleko",
+          "consumerproducts_coffeemaker_program_beverage_ristretto": "Ristretto",
+          "consumerproducts_coffeemaker_program_beverage_warmmilk": "Ciepłe mleko",
+          "consumerproducts_coffeemaker_program_beverage_xlcoffee": "Kawa XL",
+          "consumerproducts_coffeemaker_program_coffeeworld_americano": "Americano",
+          "consumerproducts_coffeemaker_program_coffeeworld_blackeye": "Blackeye",
+          "consumerproducts_coffeemaker_program_coffeeworld_cafeaulait": "Café au Lait",
+          "consumerproducts_coffeemaker_program_coffeeworld_cafeconleche": "Café Conleche",
+          "consumerproducts_coffeemaker_program_coffeeworld_cafecortado": "Café Cortado",
+          "consumerproducts_coffeemaker_program_coffeeworld_coldbrew": "Cold Brew",
+          "consumerproducts_coffeemaker_program_coffeeworld_coldbrewmacchiato": "Cold Brew Macchiato",
+          "consumerproducts_coffeemaker_program_coffeeworld_cortado": "Cortado",
+          "consumerproducts_coffeemaker_program_coffeeworld_deadeye": "Deadeye",
+          "consumerproducts_coffeemaker_program_coffeeworld_doppio": "Doppio",
+          "consumerproducts_coffeemaker_program_coffeeworld_flatwhite": "Flat White",
+          "consumerproducts_coffeemaker_program_coffeeworld_galao": "Galão",
+          "consumerproducts_coffeemaker_program_coffeeworld_garoto": "Garoto",
+          "consumerproducts_coffeemaker_program_coffeeworld_grosserbrauner": "Großer Brauner",
+          "consumerproducts_coffeemaker_program_coffeeworld_kaapi": "Kaapi",
+          "consumerproducts_coffeemaker_program_coffeeworld_kleinerbrauner": "Kleiner Brauner",
+          "consumerproducts_coffeemaker_program_coffeeworld_koffieverkeerd": "Koffie Verkeerd",
+          "consumerproducts_coffeemaker_program_coffeeworld_redeye": "Redeye",
+          "consumerproducts_coffeemaker_program_coffeeworld_slowbrew": "Slow Brew",
+          "consumerproducts_coffeemaker_program_coffeeworld_verlaengerter": "Verlängerter",
+          "consumerproducts_coffeemaker_program_coffeeworld_verlaengerterbraun": "Verlängerter Braun",
+          "consumerproducts_coffeemaker_program_coffeeworld_wienermelange": "Wiener Melange",
+          "consumerproducts_coffeemaker_program_cleaningmodes_applianceoffrinsing": "Płukanie przy wyłączaniu",
+          "consumerproducts_coffeemaker_program_cleaningmodes_applianceonrinsing": "Płukanie przy włączaniu",
+          "consumerproducts_coffeemaker_program_cleaningmodes_calcnclean": "Calc'n'Clean",
+          "consumerproducts_coffeemaker_program_cleaningmodes_clean": "Czyszczenie",
+          "consumerproducts_coffeemaker_program_cleaningmodes_cleanbrewingunitmanually": "Czyszczenie jednostki zaparzającej",
+          "consumerproducts_coffeemaker_program_cleaningmodes_cleanbrewingunitmanuallydetailed": "Czyszczenie jednostki zaparzającej (szczegółowe)",
+          "consumerproducts_coffeemaker_program_cleaningmodes_cleanoutletmanually": "Czyszczenie dyszy napojów",
+          "consumerproducts_coffeemaker_program_cleaningmodes_descale": "Odkamienianie",
+          "consumerproducts_coffeemaker_program_cleaningmodes_frostprotection": "Ochrona przed mrozem",
+          "consumerproducts_coffeemaker_program_cleaningmodes_removewaterfilter": "Wyjmowanie filtra wody",
+          "consumerproducts_coffeemaker_program_cleaningmodes_replacewaterfilter": "Wymiana filtra wody",
+          "consumerproducts_coffeemaker_program_cleaningmodes_rinsemilksystem": "Płukanie systemu mleka",
+          "consumerproducts_coffeemaker_program_cleaningmodes_rinsewaterfilter": "Płukanie filtra wody",
+          "consumerproducts_coffeemaker_program_cleaningmodes_specialrinsing": "Specjalne płukanie",
+          "laundrycare_common_program_memory1": "Pamięć 1",
+          "laundrycare_common_program_memory2": "Pamięć 2",
+          "laundrycare_common_program_memory3": "Pamięć 3",
+          "laundrycare_common_program_memory4": "Pamięć 4",
+          "laundrycare_common_program_memory5": "Pamięć 5",
+          "laundrycare_common_program_memory6": "Pamięć 6",
+          "laundrycare_common_program_memory7": "Pamięć 7",
+          "laundrycare_common_program_memory8": "Pamięć 8",
+          "cooking_hob_program_dish_fryingsensor_creamsauce": "Czujnik smażenia: Sos śmietanowy",
+          "cooking_hob_program_dish_fryingsensor_dumplings": "Czujnik smażenia: Pierogi/Kluski",
+          "cooking_hob_program_dish_fryingsensor_fondue": "Czujnik smażenia: Fondue",
+          "cooking_hob_program_dish_fryingsensor_meltingbutter": "Czujnik smażenia: Roztapianie masła",
+          "cooking_hob_program_dish_fryingsensor_meltingcheese": "Czujnik smażenia: Roztapianie sera",
+          "cooking_hob_program_dish_fryingsensor_meltingchocolate": "Czujnik smażenia: Roztapianie czekolady",
+          "cooking_hob_program_dish_fryingsensor_mussels": "Czujnik smażenia: Małże",
+          "cooking_hob_program_dish_fryingsensor_onionrings": "Czujnik smażenia: Krążki cebuli",
+          "cooking_hob_program_dish_fryingsensor_ribeyemedium": "Czujnik smażenia: Ribeye (średni)",
+          "cooking_hob_program_dish_fryingsensor_ribeyerare": "Czujnik smażenia: Ribeye (krwisty)",
+          "cooking_hob_program_dish_fryingsensor_sardines": "Czujnik smażenia: Sardynki",
+          "cooking_hob_program_dish_fryingsensor_skewers": "Czujnik smażenia: Szaszłyki",
+          "cooking_hob_program_dish_fryingsensor_squid": "Czujnik smażenia: Kalmary",
+          "cooking_hob_program_dish_fryingsensor_tempuravegetables": "Czujnik smażenia: Warzywa w tempurze",
+          "cooking_hob_program_dish_fryingsensor_toastingbread": "Czujnik smażenia: Tostowanie chleba",
+          "favorite_011": "Ulubiony 11",
+          "favorite_012": "Ulubiony 12",
+          "favorite_013": "Ulubiony 13",
+          "favorite_014": "Ulubiony 14",
+          "favorite_015": "Ulubiony 15",
+          "favorite_016": "Ulubiony 16",
+          "favorite_017": "Ulubiony 17",
+          "favorite_018": "Ulubiony 18",
+          "favorite_019": "Ulubiony 19",
+          "favorite_020": "Ulubiony 20",
+          "favorite_021": "Ulubiony 21",
+          "favorite_022": "Ulubiony 22",
+          "favorite_023": "Ulubiony 23",
+          "favorite_024": "Ulubiony 24",
+          "favorite_025": "Ulubiony 25",
+          "favorite_026": "Ulubiony 26",
+          "favorite_027": "Ulubiony 27",
+          "favorite_028": "Ulubiony 28",
+          "favorite_029": "Ulubiony 29",
+          "favorite_030": "Ulubiony 30"
+        }
+      },
+      "select_sensitivity_turbidity": {
+        "name": "Czułość czujnika zmętnienia",
+        "state": {
+          "standard": "standardowa",
+          "sensitive": "czuła",
+          "verysensitive": "bardzo czuła"
+        }
+      },
+      "select_eco_as_default": {
+        "name": "Domyślny program",
+        "state": {
+          "lastprogram": "ostatni program",
+          "auto45asdefault": "Auto"
+        }
+      },
+      "select_power_state": {
+        "name": "Stan zasilania",
+        "state": {
+          "mainsoff": "sieć wyłączona",
+          "off": "wyłączone",
+          "on": "włączone",
+          "standby": "tryb czuwania"
+        }
+      },
+      "select_coffee_temperature": {
+        "name": "Temperatura kawy",
+        "state": {
+          "88c": "88 °C",
+          "90c": "90 °C",
+          "92c": "92 °C",
+          "94c": "94 °C",
+          "95c": "95 °C",
+          "96c": "96 °C",
+          "98c": "98 °C"
+        }
+      },
+      "select_bean_amount": {
+        "name": "Ilość ziaren",
+        "state": {
+          "verymild": "bardzo łagodna",
+          "mild": "łagodna",
+          "mildplus": "łagodna plus",
+          "normal": "normalna",
+          "normalplus": "normalna plus",
+          "strong": "mocna",
+          "strongplus": "mocna plus",
+          "verystrong": "bardzo mocna",
+          "verystrongplus": "bardzo mocna plus",
+          "extrastrong": "extra mocna",
+          "doubleshot": "double shot",
+          "doubleshotplus": "double shot plus",
+          "doubleshotplusplus": "double shot plus plus",
+          "tripleshot": "triple shot",
+          "tripleshotplus": "triple shot plus",
+          "coffeeground": "kawa mielona"
+        }
+      },
+      "select_beverage_size": {
+        "name": "Wielkość napoju",
+        "state": {
+          "small": "mała",
+          "medium": "średnia",
+          "large": "duża",
+          "verylarge": "bardzo duża"
+        }
+      },
+      "select_coffee_milk_ratio": {
+        "name": "Stosunek kawy do mleka",
+        "state": {
+          "10percent": "10%",
+          "20percent": "20%",
+          "25percent": "25%",
+          "30percent": "30%",
+          "40percent": "40%",
+          "50percent": "50%",
+          "55percent": "55%",
+          "60percent": "60%",
+          "65percent": "65%",
+          "67percent": "67%",
+          "70percent": "70%",
+          "75percent": "75%",
+          "80percent": "80%",
+          "85percent": "85%",
+          "90percent": "90%"
+        }
+      },
+      "select_hot_water_temperature": {
+        "name": "Temperatura gorącej wody",
+        "state": {
+          "60c": "60 °C",
+          "70c": "70 °C",
+          "75c": "75 °C",
+          "80c": "80 °C",
+          "85c": "85 °C",
+          "90c": "90 °C",
+          "95c": "95 °C",
+          "97c": "97 °C"
+        }
+      },
+      "select_flow_rate": {
+        "name": "Przepływ wody",
+        "state": {
+          "normal": "normalny",
+          "intense": "intensywny",
+          "intenseplus": "intensywny plus"
+        }
+      },
+      "select_coarsness": {
+        "name": "Grubość mielenia",
+        "state": {
+          "coarsness1": "grubość 1",
+          "coarsness2": "grubość 2",
+          "coarsness3": "grubość 3",
+          "coarsness4": "grubość 4",
+          "coarsness5": "grubość 5",
+          "coarsness6": "grubość 6"
+        }
+      },
+      "select_coffee_strength": {
+        "name": "Moc kawy",
+        "state": {
+          "strength1": "moc 1",
+          "strength2": "moc 2",
+          "strength3": "moc 3",
+          "strength4": "moc 4",
+          "strength5": "moc 5",
+          "strength6": "moc 6",
+          "strength7": "moc 7",
+          "strength8": "moc 8",
+          "strength9": "moc 9"
+        }
+      },
+      "select_aroma_select": {
+        "name": "Wybór aromatu",
+        "state": {
+          "fine": "delikatny",
+          "balanced": "zrównoważony",
+          "distinctive": "wyrazisty"
+        }
+      },
+      "select_bean_container": {
+        "name": "Zbiornik na ziarna",
+        "state": {
+          "right": "prawy",
+          "left": "lewy"
+        }
+      },
+      "select_shot_count": {
+        "name": "Liczba shotów",
+        "state": {
+          "double": "podwójny",
+          "triple": "potrójny"
+        }
+      },
+      "select_cups": {
+        "name": "Liczba filiżanek",
+        "state": {
+          "two": "dwie",
+          "four": "cztery",
+          "six": "sześć"
+        }
+      },
+      "select_auto_power_off": {
+        "name": "Auto wyłączenie",
+        "state": {
+          "off": "wyłączone",
+          "15min": "15 min",
+          "30min": "30 min",
+          "60min": "60 min"
+        }
+      },
+      "select_laundry_brightness": {
+        "name": "Poziom jasności",
+        "state": {
+          "low": "niski",
+          "medium": "średni",
+          "high": "wysoki",
+          "veryhigh": "bardzo wysoki"
+        }
+      },
+      "select_door_light_ring_mode": {
+        "name": "Tryb pierścienia świetlnego drzwi",
+        "state": {
+          "off": "wyłączone",
+          "on": "włączone",
+          "auto": "auto"
+        }
+      },
+      "select_door_light_ring_brightness": {
+        "name": "Poziom jasności pierścienia świetlnego drzwi",
+        "state": {
+          "low": "niski",
+          "medium": "średni",
+          "high": "wysoki",
+          "veryhigh": "bardzo wysoki"
+        }
+      },
+      "select_laundry_end_signal_volume": {
+        "name": "Głośność sygnału końca",
+        "state": {
+          "off": "wyłączone",
+          "low": "niska",
+          "medium": "średnia",
+          "loud": "głośna",
+          "veryloud": "bardzo głośna"
+        }
+      },
+      "select_laundry_key_signal_volume": {
+        "name": "Głośność sygnału klawiszy",
+        "state": {
+          "off": "wyłączone",
+          "low": "niska",
+          "medium": "średnia",
+          "loud": "głośna",
+          "veryloud": "bardzo głośna"
+        }
+      },
+      "select_laundry_sound_volume": {
+        "name": "Głośność sygnału klawiszy",
+        "state": {
+          "off": "wyłączone",
+          "volume1": "głośność 1",
+          "volume2": "głośność 2",
+          "volume3": "głośność 3",
+          "volume4": "głośność 4"
+        }
+      },
+      "select_laundry_power_rating": {
+        "name": "Znamionowa moc zasilania"
+      },
+      "select_laundry_wrinkle_guard": {
+        "name": "Ochrona przed gnieceniem",
+        "state": {
+          "off": "wyłączone",
+          "min30": "30 min",
+          "min60": "60 min",
+          "min90": "90 min",
+          "min120": "120 min",
+          "min180": "180 min"
+        }
+      },
+      "select_laundry_cupboard_dry_fine_adjust": {
+        "name": "Regulacja – suche do szafy",
+        "state": {
+          "off": "wyłączone",
+          "plus1": "plus 1",
+          "plus2": "plus 2",
+          "plus3": "plus 3"
+        }
+      },
+      "select_laundry_cupboard_dry_plus_fine_adjust": {
+        "name": "Regulacja – suche do szafy plus",
+        "state": {
+          "off": "wyłączone",
+          "plus1": "plus 1",
+          "plus2": "plus 2",
+          "plus3": "plus 3"
+        }
+      },
+      "select_laundry_iron_dry_fine_adjust": {
+        "name": "Regulacja – suche do prasowania",
+        "state": {
+          "off": "wyłączone",
+          "plus1": "plus 1",
+          "plus2": "plus 2",
+          "plus3": "plus 3"
+        }
+      },
+      "select_laundry_spin_speed_before_drying": {
+        "name": "Prędkość wirowania przed suszeniem",
+        "state": {
+          "off": "wyłączone",
+          "rpm400": "400 rpm",
+          "rpm600": "600 rpm",
+          "rpm700": "700 rpm",
+          "rpm800": "800 rpm",
+          "rpm900": "900 rpm",
+          "rpm1000": "1000 rpm",
+          "rpm1200": "1200 rpm",
+          "rpm1400": "1400 rpm",
+          "rpm1500": "1500 rpm",
+          "rpm1600": "1600 rpm",
+          "auto": "auto"
+        }
+      },
+      "select_laundry_drying_target": {
+        "name": "Cel suszenia",
+        "state": {
+          "irondry": "suche do prasowania",
+          "gentledry": "delikatne suszenie",
+          "cupboarddry": "suche do szafy",
+          "cupboarddryplus": "suche do szafy plus",
+          "extradry": "extra suche"
+        }
+      },
+      "select_laundry_refresher": {
+        "name": "Cel suszenia",
+        "state": {
+          "shirt1": "koszula 1",
+          "shirt5": "koszula 5",
+          "business": "biznesowe"
+        }
+      },
+      "select_laundry_idos2_content": {
+        "name": "Zawartość i-DOS 2",
+        "state": {
+          "softener": "zmiękczacz",
+          "detergent": "detergent"
+        }
+      },
+      "select_laundry_idos2_level": {
+        "name": "Poziom i-DOS 2",
+        "state": {
+          "off": "wyłączone",
+          "light": "lekki",
+          "normal": "normalny",
+          "strong": "mocny"
+        }
+      },
+      "select_laundry_idos1_level": {
+        "name": "Poziom i-DOS 1",
+        "state": {
+          "off": "wyłączone",
+          "light": "lekki",
+          "normal": "normalny",
+          "strong": "mocny"
+        }
+      },
+      "select_laundry_vario_perfect": {
+        "name": "VarioPerfect",
+        "state": {
+          "off": "wyłączone",
+          "ecoperfect": "EcoPerfect",
+          "speedperfect": "SpeedPerfect"
+        }
+      },
+      "select_laundry_hygienic_steam_intensity": {
+        "name": "Intensywność pary higienicznej",
+        "state": {
+          "middle": "średnia",
+          "high": "wysoka"
+        }
+      },
+      "select_laundry_multiple_soak": {
+        "name": "Wielokrotne moczenie",
+        "state": {
+          "off": "wyłączone",
+          "plus1": "plus 1",
+          "plus2": "plus 2",
+          "plus3": "plus 3"
+        }
+      },
+      "select_laundry_rinseplus": {
+        "name": "Dodatkowe płukanie",
+        "state": {
+          "off": "wyłączone",
+          "plus1": "plus 1",
+          "plus2": "plus 2",
+          "plus3": "plus 3"
+        }
+      },
+      "select_laundry_spin_speed": {
+        "name": "Prędkość wirowania",
+        "state": {
+          "off": "wyłączone",
+          "uloff": "ultra wył.",
+          "rpm1000": "1000 rpm",
+          "ulhigh": "ultra wysoka",
+          "rpm1200": "1200 rpm",
+          "rpm1400": "1400 rpm",
+          "rpm1500": "1500 rpm",
+          "rpm1600": "1600 rpm",
+          "auto": "auto",
+          "max": "max",
+          "ullow": "ultra niska",
+          "rpm400": "400 rpm",
+          "rpm600": "600 rpm",
+          "rpm700": "700 rpm",
+          "ulmedium": "ultra średnia",
+          "rpm800": "800 rpm",
+          "rpm900": "900 rpm"
+        }
+      },
+      "select_laundry_option_stains": {
+        "name": "Plamy",
+        "state": {
+          "off": "wyłączone",
+          "babyfood": "jedzenie dla dzieci",
+          "perspiration": "pot",
+          "socks": "skarpety",
+          "butteroil": "masło/olej",
+          "tea": "herbata",
+          "tomatosauce": "sos pomidorowy",
+          "strawberry": "truskawka",
+          "orange": "pomarańcza",
+          "blood": "krew",
+          "egg": "jajko",
+          "mud": "błoto",
+          "grass": "trawa",
+          "coffee": "kawa",
+          "cosmetics": "kosmetyki",
+          "redwine": "czerwone wino",
+          "chocolate": "czekolada"
+        }
+      },
+      "select_laundry_option_temperature": {
+        "name": "Temperatura prania",
+        "state": {
+          "cold": "zimna",
+          "gc20": "20°C",
+          "ulcold": "ultra zimna",
+          "ulwarm": "ultra ciepła",
+          "ulhot": "ultra gorąca",
+          "ulextrahot": "ultra ekstra gorąca",
+          "gc30": "30°C",
+          "auto": "auto",
+          "max": "max",
+          "gc40": "40°C",
+          "gc50": "50°C",
+          "gc60": "60°C",
+          "gc70": "70°C",
+          "gc80": "80°C",
+          "gc90": "90°C"
+        }
+      },
+      "select_laundry_option_water_and_rinse_plus": {
+        "name": "Woda i dodatkowe płukanie",
+        "state": {
+          "off": "wyłączone",
+          "plus1": "plus 1",
+          "plus2": "plus 2",
+          "plus3": "plus 3"
+        }
+      },
+      "select_oven_level": {
+        "name": "Poziom",
+        "state": {
+          "level01": "poziom 1",
+          "level02": "poziom 2",
+          "level03": "poziom 3"
+        }
+      },
+      "select_oven_used_heating_mode": {
+        "name": "Tryb grzania",
+        "state": {
+          "automaticoperation": "operacja automatyczna",
+          "automaticoperationwithmicrowave": "operacja automatyczna z mikrofalami",
+          "bakingsensoroperation": "operacja z czujnikiem pieczenia",
+          "bottomheating": "nagrzewanie dolne",
+          "defrosting": "rozmrażanie",
+          "desiccation": "osuszanie",
+          "doughproving": "wyrastanie ciasta",
+          "frozenheatupspecial": "funkcja coolstart",
+          "grilllargearea": "grillowanie, duży obszar",
+          "grillsmallarea": "grillowanie, mały obszar",
+          "hotair": "termoobieg",
+          "hotaireco": "termoobieg eco",
+          "hotairgrilling": "grillowanie z termoobiegiem",
+          "intensiveheat": "intensywne grzanie",
+          "keepwarm": "podtrzymywanie ciepła",
+          "microwave": "mikrofale",
+          "pizzasetting": "ustawienie pizza",
+          "preheatovenware": "podgrzewanie naczyń",
+          "reheat": "podgrzewanie",
+          "sabbathprogramme": "program szabatu",
+          "slowcook": "wolne gotowanie",
+          "steam": "para",
+          "topbottomheating": "grzanie górne i dolne",
+          "topbottomheatingeco": "grzanie górne i dolne eco",
+          "breadbaking": "pieczenie chleba",
+          "steamwithsteamset": "para z zestawem parowym"
+        }
+      },
+      "select_pyrolysis_level": {
+        "name": "Poziom pirolizy",
+        "state": {
+          "level01": "poziom 1",
+          "level02": "poziom 2",
+          "level03": "poziom 3"
+        }
+      },
+      "select_oven_child_lock_setting": {
+        "name": "Ustawienie blokady dla dzieci",
+        "state": {
+          "deactivated": "dezaktywowana",
+          "activated": "aktywowana",
+          "activatedwithdoorlock": "aktywowana z blokadą drzwi"
+        }
+      },
+      "select_oven_switch_on_delay": {
+        "name": "Opóźnienie włączenia",
+        "state": {
+          "short": "krótkie",
+          "medium": "średnie",
+          "long": "długie"
+        }
+      },
+      "select_oven_cooling_fan_runtime": {
+        "name": "Czas pracy wentylatora chłodzącego",
+        "state": {
+          "short": "krótki",
+          "recommended": "zalecany",
+          "middle": "Zalecany",
+          "long": "Długi",
+          "verylong": "Bardzo długi"
+        }
+      },
+      "select_oven_signal_duration": {
+        "name": "Czas trwania sygnału",
+        "state": {
+          "short": "krótki",
+          "medium": "średni",
+          "long": "długi",
+          "onlyonetime": "Tylko raz"
+        }
+      },
+      "select_refrigerator_door_assistant_freezer_trigger": {
+        "name": "Wyzwalacz asystenta drzwi zamrażarki",
+        "state": {
+          "push": "pchnięcie",
+          "pull": "pociągnięcie",
+          "pushpull": "pchnięcie/pociągnięcie"
+        }
+      },
+      "select_refrigerator_door_assistant_freezer_force": {
+        "name": "Siła asystenta drzwi zamrażarki",
+        "state": {
+          "lowforce": "niska",
+          "middleforce": "średnia",
+          "highforce": "wysoka"
+        }
+      },
+      "select_refrigerator_door_assistant_fridge_trigger": {
+        "name": "Wyzwalacz asystenta drzwi chłodziarki",
+        "state": {
+          "push": "pchnięcie",
+          "pull": "pociągnięcie",
+          "pushpull": "pchnięcie/pociągnięcie"
+        }
+      },
+      "select_refrigerator_door_assistant_fridge_force": {
+        "name": "Siła asystenta drzwi chłodziarki",
+        "state": {
+          "lowforce": "niska",
+          "middleforce": "średnia",
+          "highforce": "wysoka"
+        }
+      },
+      "select_chiller_common_preset": {
+        "name": "Ustawienie chillera",
+        "state": {
+          "meatfish": "29°F \uD83D\uDCA7 (mięso/ryba)",
+          "fruit": "32°F \uD83D\uDCA7 (owoce)",
+          "vegetables": "32°F \uD83D\uDCA7\uD83D\uDCA7 (warzywa)",
+          "beverages": "34°F \uD83D\uDCA7 (napoje)",
+          "snacks": "40°F \uD83D\uDCA7 (przekąski/inne)",
+          "custom": "własne"
+        }
+      },
+      "select_chiller_left_humidity": {
+        "name": "Wilgotność lewego chillera",
+        "state": {
+          "low": "niska",
+          "high": "wysoka"
+        }
+      },
+      "select_chiller_right_humidity": {
+        "name": "Wilgotność prawego chillera",
+        "state": {
+          "low": "niska",
+          "high": "wysoka"
+        }
+      },
+      "select_hob_automatic_keylock": {
+        "name": "Automatyczna blokada przycisków",
+        "state": {
+          "deactivated": "ręczna",
+          "activated": "automatyczna",
+          "keylockfunctiondeactivated": "wyłączona"
+        }
+      },
+      "select_hob_bridge_zone_mode": {
+        "name": "Vario Induction",
+        "state": {
+          "splitmode": "rozdzielone",
+          "joinmode": "połączone"
+        }
+      },
+      "select_hob_power_level": {
+        "name": "Poziom mocy"
+      },
+      "select_hob_hood_automatic_start": {
+        "name": "Automatyczny start okapu",
+        "state": {
+          "off": "wyłączony",
+          "automaticmode": "automatyczny",
+          "manualmode": "ręczny"
+        }
+      },
+      "select_hob_hood_after_run": {
+        "name": "Dobieg okapu",
+        "state": {
+          "off": "wyłączony",
+          "automaticmode": "automatyczny",
+          "manualmode": "ręczny",
+          "donothing": "bez zmian"
+        }
+      },
+      "select_hob_power_management": {
+        "name": "Maksymalny pobór mocy"
+      },
+      "select_hob_buzzer_beep_level": {
+        "name": "Poziom sygnału dźwiękowego",
+        "state": {
+          "alloff": "wszystkie wyłączone",
+          "acknowledgeoff": "dźwięki przycisków wyłączone",
+          "warningmaloff": "ostrzeżenia wyłączone",
+          "allactive": "wszystkie aktywne"
+        }
+      },
+      "select_hob_end_timer_signal_duration": {
+        "name": "Czas trwania sygnału końca timera"
+      },
+      "select_hob_delaye_shutoff_stage": {
+        "name": "Stopień opóźnionego wyłączenia",
+        "state": {
+          "fanoff": "wyłączone",
+          "fanstage01": "1",
+          "fanstage02": "2",
+          "fanstage03": "3",
+          "fanstage04": "4"
+        }
+      },
+      "select_temperature_unit": {
+        "name": "Jednostka temperatury",
+        "state": {
+          "celsius": "celsjusz",
+          "fahrenheit": "fahrenheit"
+        }
+      },
+      "select_hood_interval_stage": {
+        "name": "Stopień interwałowy",
+        "state": {
+          "fanoff": "wyłączone",
+          "fanstage01": "1",
+          "fanstage02": "2",
+          "fanstage03": "3",
+          "fanstage04": "4"
+        }
+      },
+      "select_hood_carbon_filter_type": {
+        "name": "Typ filtra węglowego",
+        "state": {
+          "none": "brak",
+          "basiccarbonfilter": "podstawowy filtr węglowy",
+          "regenerativecarbonfilter": "regeneracyjny filtr węglowy"
+        }
+      },
+      "select_hood_boost": {
+        "name": "Boost",
+        "state": {
+          "intensivestageoff": "wyłączony",
+          "intensivestage1": "1",
+          "intensivestage2": "2"
+        }
+      },
+      "select_hood_color_temperature_mode": {
+        "name": "Tryb temperatury barwowej",
+        "state": {
+          "custom": "niestandardowa",
+          "warm": "ciepła",
+          "warmtoneutral": "od ciepłej do neutralnej",
+          "neutral": "neutralna",
+          "neutraltocold": "od neutralnej do zimnej",
+          "cold": "zimna"
+        }
+      }
+    },
+    "button": {
+      "button_abort_program": {
+        "name": "Przerwij"
+      },
+      "button_start_program": {
+        "name": "Start"
+      },
+      "button_pause_program": {
+        "name": "Wstrzymaj"
+      },
+      "button_resume_program": {
+        "name": "Wznów"
+      },
+      "button_mains_power_off": {
+        "name": "Wyłącz zasilanie"
+      },
+      "button_hood_carbon_filter_reset": {
+        "name": "Resetuj filtr węglowy"
+      },
+      "button_hood_grease_filter_reset": {
+        "name": "Resetuj filtr tłuszczowy"
+      },
+      "button_hood_regenerative_carbon_filter_reset": {
+        "name": "Resetuj regeneracyjny filtr węglowy"
+      },
+      "button_hood_regenerative_carbon_filter_lifetime_reset": {
+        "name": "Resetuj żywotność regeneracyjnego filtra węglowego"
+      }
+    },
+    "number": {
+      "number_fill_quantity": {
+        "name": "Ilość wody"
+      },
+      "number_refrigerator_sabbath_mode_duration": {
+        "name": "Czas trwania trybu szabatowego"
+      },
+      "number_laundry_brightness": {
+        "name": "Jasność"
+      },
+      "number_door_light_ring_brightness": {
+        "name": "Jasność pierścienia świetlnego drzwi"
+      },
+      "number_duration": {
+        "name": "Czas trwania"
+      },
+      "number_laundry_spin_class": {
+        "name": "Klasa wirowania"
+      },
+      "number_setpoint_freezer": {
+        "name": "Temperatura zamrażarki"
+      },
+      "number_setpoint_refrigerator": {
+        "name": "Temperatura lodówki"
+      },
+      "number_setpoint_chiller_common": {
+        "name": "Temperatura schładzarki"
+      },
+      "number_light_internal_brightness": {
+        "name": "Jasność oświetlenia wewnętrznego"
+      },
+      "number_idos1_base_level": {
+        "name": "Dawka i-DOS: detergent"
+      },
+      "number_idos2_base_level": {
+        "name": "Dawka i-DOS: detergent lub zmiękczacz"
+      },
+      "number_oven_setpoint_temperature": {
+        "name": "Temperatura docelowa"
+      },
+      "number_oven_display_brightness": {
+        "name": "Jasność wyświetlacza"
+      },
+      "number_oven_sound_volume": {
+        "name": "Głośność"
+      },
+      "number_hob_automatic_timer": {
+        "name": "Timer automatyczny"
+      },
+      "number_hood_interval_off": {
+        "name": "Czas wyłączenia w trybie interwałowym"
+      },
+      "number_hood_interval_on": {
+        "name": "Czas włączenia w trybie interwałowym"
+      },
+      "number_hood_delayed_shutoff_time": {
+        "name": "Czas opóźnionego wyłączenia"
+      },
+      "number_refrigerator_door_assistant_freezer_timeout": {
+        "name": "Czas asystenta drzwi zamrażarki"
+      },
+      "number_refrigerator_door_assistant_fridge_timeout": {
+        "name": "Czas asystenta drzwi chłodziarki"
+      },
+      "number_hood_sensor_sensitivity": {
+        "name": "Czułość czujnika automatycznego"
+      },
+      "number_start_in": {
+        "name": "Start za"
+      },
+      "number_setting_alarm_clock": {
+        "name": "Minutnik"
+      }
+    },
+    "light": {
+      "light_door_ring": {
+        "name": "Pierścień świetlny drzwi"
+      },
+      "light_drum_light": {
+        "name": "Oświetlenie bębna"
+      },
+      "light_internal": {
+        "name": "Oświetlenie wewnętrzne"
+      },
+      "light_logo": {
+        "name": "Podświetlenie logo"
+      },
+      "light_cooking_lighting": {
+        "name": "Oświetlenie"
+      },
+      "light_cooking_ambient_lighting": {
+        "name": "Oświetlenie ambientowe"
+      }
+    },
+    "fan": {
+      "fan_hood": {
+        "name": "Wentylator"
+      }
+    },
+    "update": {
+      "update_software_download": {
+        "name": "Pobieranie oprogramowania"
+      },
+      "update_software_update": {
+        "name": "Aktualizacja oprogramowania"
+      }
+    }
+  },
+  "services": {
+    "start_program": {
+      "name": "Uruchom program",
+      "description": "Uruchamia wybrany program",
+      "fields": {
+        "device_id": {
+          "name": "Urządzenie",
+          "description": "Urządzenie, na którym ma zostać uruchomiony program"
+        },
+        "start_in": {
+          "name": "Uruchom za",
+          "description": "Opóźnij uruchomienie programu"
+        },
+        "finish_in": {
+          "name": "Zakończ za",
+          "description": "Czas, po którym program ma się zakończyć"
+        }
+      }
+    },
+    "set_start_in": {
+      "name": "Ustaw opóźnienie startu",
+      "description": "Ustawia opóźnienie startu",
+      "fields": {
+        "device_id": {
+          "name": "Urządzenie",
+          "description": "Urządzenie, dla którego ma zostać ustawione opóźnienie startu"
+        },
+        "start_in": {
+          "name": "Opóźnienie",
+          "description": "Ustaw opóźnienie startu"
+        },
+        "finish_in": {
+          "name": "Zakończ za",
+          "description": "Ustaw czas, po którym program ma się zakończyć"
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "start_in_not_available": {
+      "message": "Opcja 'Uruchom za' nie jest dostępna w tym urządzeniu"
+    },
+    "finish_in_not_available": {
+      "message": "Opcja 'Zakończ za' nie jest dostępna w tym urządzeniu"
+    },
+    "start_program_error": {
+      "message": "Błąd {code} podczas uruchamiania programu, zasób {resource}"
+    },
+    "no_program_selected": {
+      "message": "Nie wybrano programu"
+    },
+    "auth_failed": {
+      "message": "Uwierzytelnianie nie powiodło się: {host}"
+    },
+    "cannot_connect": {
+      "message": "Nie można połączyć się z {host}"
+    },
+    "no_device_info": {
+      "message": "Urządzenie nie ma informacji o urządzeniu"
+    },
+    "speed_invalid": {
+      "message": "Prędkość {percentage} jest nieprawidłowa"
+    },
+    "not_appliance": {
+      "message": "To nie jest urządzenie Homeconnect"
+    },
+    "access_error": {
+      "message": "Encja jest niedostępna"
+    },
+    "code_respons": {
+      "message": "Błędna odpowiedź z urządzenia: {message}"
+    },
+    "not_connected": {
+      "message": "Klient nie jest połączony"
+    }
+  }
+}


### PR DESCRIPTION
Adds a full Polish (`pl.json`) translation for the `beta` branch — every key in `beta`'s `en.json` is translated 1:1, no untranslated or out-of-scope keys.

Companion to #34 (targeting `main`). No `en.json` changes — this only adds the Polish file, covering:
- Everything #34 covers for `main`.
- Every key `beta` has beyond `main`: hob automatic keylock, Vario Induction bridge zone, buzzer beep level, hood after-run/automatic-start, hood boost/color-temperature mode, washer-dryer combo programs, oven convection bake/proof, and a handful of hob/oven switches (energy consumption indication, hood auto light on/off, night dimout, brand logo, telescopic slide-out).
- ~1000 hob/oven program and recipe names that were previously untranslated.