### PR TITLE
refrigeration: attach internal light brightness to the light entity

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/refrigeration.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/refrigeration.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.number import NumberDeviceClass, NumberMode
 from homeassistant.components.sensor import SensorDeviceClass
@@ -17,6 +19,49 @@ from .descriptions_definitions import (
     HCSwitchEntityDescription,
     _EntityDescriptionsDefinitionsType,
 )
+
+if TYPE_CHECKING:
+    from home_disconnect import HomeAppliance
+
+
+def generate_internal_light(appliance: HomeAppliance) -> HCLightEntityDescription | None:
+    """Get internal light description."""
+    if "Refrigeration.Common.Setting.Light.Internal.Power" not in appliance.entities:
+        return None
+
+    if "Refrigeration.Common.Setting.Light.Internal.Brightness" in appliance.entities:
+        return HCLightEntityDescription(
+            key="light_internal",
+            entity="Refrigeration.Common.Setting.Light.Internal.Power",
+            brightness_entity="Refrigeration.Common.Setting.Light.Internal.Brightness",
+        )
+
+    return HCLightEntityDescription(
+        key="light_internal",
+        entity="Refrigeration.Common.Setting.Light.Internal.Power",
+    )
+
+
+def generate_internal_light_brightness(
+    appliance: HomeAppliance,
+) -> HCNumberEntityDescription | None:
+    """Get internal light brightness description."""
+    if "Refrigeration.Common.Setting.Light.Internal.Brightness" not in appliance.entities:
+        return None
+
+    # The light entity already exposes brightness, so this would be a
+    # second control for the same setting.
+    owned_by_light = "Refrigeration.Common.Setting.Light.Internal.Power" in appliance.entities
+
+    return HCNumberEntityDescription(
+        key="number_light_internal_brightness",
+        entity="Refrigeration.Common.Setting.Light.Internal.Brightness",
+        native_unit_of_measurement=PERCENTAGE,
+        mode=NumberMode.AUTO,
+        native_step=1,
+        entity_registry_enabled_default=not owned_by_light,
+    )
+
 
 REFRIGERATION_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
     "binary_sensor": [
@@ -256,13 +301,7 @@ REFRIGERATION_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             mode=NumberMode.AUTO,
             native_step=1,
         ),
-        HCNumberEntityDescription(
-            key="number_light_internal_brightness",
-            entity="Refrigeration.Common.Setting.Light.Internal.Brightness",
-            native_unit_of_measurement=PERCENTAGE,
-            mode=NumberMode.AUTO,
-            native_step=1,
-        ),
+        generate_internal_light_brightness,
         HCNumberEntityDescription(
             key="number_refrigerator_door_assistant_freezer_timeout",
             entity="Refrigeration.Common.Setting.Door.AssistantTimeoutFreezer",
@@ -429,10 +468,7 @@ REFRIGERATION_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
         ),
     ],
     "light": [
-        HCLightEntityDescription(
-            key="light_internal",
-            entity="Refrigeration.Common.Setting.Light.Internal.Power",
-        ),
+        generate_internal_light,
         HCLightEntityDescription(
             key="light_logo",
             entity="Refrigeration.Common.Setting.Light.Logo.Power",

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -18,6 +18,10 @@ from custom_components.homeconnect_ws.entity_descriptions.common import (
     generate_program,
 )
 from custom_components.homeconnect_ws.entity_descriptions.cooking import generate_hood_light
+from custom_components.homeconnect_ws.entity_descriptions.refrigeration import (
+    generate_internal_light,
+    generate_internal_light_brightness,
+)
 from custom_components.homeconnect_ws.helpers import merge_dicts
 from custom_components.homeconnect_ws.select import HCSelect
 from home_disconnect.entities import Access, DeviceDescription, EntityDescription
@@ -447,3 +451,64 @@ async def test_hood_color_temperature_mode_select(
 
     await appliance.entities["Cooking.Hood.Setting.ColorTemperature"].update({"value": 4})
     assert entity.current_option == "neutraltocold"
+
+
+INTERNAL_LIGHT = DeviceDescription(
+    setting=[
+        EntityDescription(
+            uid=0x5001,
+            name="Refrigeration.Common.Setting.Light.Internal.Power",
+            access=Access.READ_WRITE,
+            available=True,
+        ),
+        EntityDescription(
+            uid=0x5002,
+            name="Refrigeration.Common.Setting.Light.Internal.Brightness",
+            access=Access.READ_WRITE,
+            available=True,
+            max=100,
+            min=0,
+        ),
+    ]
+)
+
+
+async def test_internal_light(mock_homeconnect_appliance: MockApplianceType) -> None:
+    """Test dynamic internal light."""
+    # Power + Brightness
+    appliance = await mock_homeconnect_appliance(description=INTERNAL_LIGHT)
+    assert generate_internal_light(appliance) == HCLightEntityDescription(
+        key="light_internal",
+        entity="Refrigeration.Common.Setting.Light.Internal.Power",
+        brightness_entity="Refrigeration.Common.Setting.Light.Internal.Brightness",
+    )
+
+    # Power only
+    power_only = DeviceDescription(setting=[INTERNAL_LIGHT["setting"][0]])
+    appliance = await mock_homeconnect_appliance(description=power_only)
+    assert generate_internal_light(appliance) == HCLightEntityDescription(
+        key="light_internal",
+        entity="Refrigeration.Common.Setting.Light.Internal.Power",
+    )
+
+    # No internal light
+    appliance = await mock_homeconnect_appliance(description={})
+    assert generate_internal_light(appliance) is None
+
+
+async def test_internal_light_brightness(mock_homeconnect_appliance: MockApplianceType) -> None:
+    """Test the brightness number defers to the light entity."""
+    # Light entity owns brightness, so the number is opt-in
+    appliance = await mock_homeconnect_appliance(description=INTERNAL_LIGHT)
+    description = generate_internal_light_brightness(appliance)
+    assert description.entity_registry_enabled_default is False
+
+    # No light entity to own it, so the number is the only control
+    brightness_only = DeviceDescription(setting=[INTERNAL_LIGHT["setting"][1]])
+    appliance = await mock_homeconnect_appliance(description=brightness_only)
+    description = generate_internal_light_brightness(appliance)
+    assert description.entity_registry_enabled_default is True
+
+    # No brightness at all
+    appliance = await mock_homeconnect_appliance(description={})
+    assert generate_internal_light_brightness(appliance) is None

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -744,3 +744,40 @@ async def test_set_color(
         )
     )
     mock_appliance.session.send_sync.reset_mock()
+
+
+async def test_turn_on_when_brightness_has_no_value(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,  # noqa: ARG001
+) -> None:
+    """Test turning on while the appliance reports no brightness value."""
+    assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
+    # The appliance drops the brightness value while the light is off. The
+    # entity cannot be updated to None, so clear it the way a never-received
+    # value leaves it.
+    await mock_appliance.entities["Test.Lighting"].update({"value": False})
+    mock_appliance.entities["Test.LightingBrightness"]._value = None
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.fake_brand_homeappliance_light_2")
+    assert state
+    assert state.attributes[ATTR_BRIGHTNESS] is None
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: "light.fake_brand_homeappliance_light_2",
+            ATTR_BRIGHTNESS_PCT: 100,
+        },
+        blocking=True,
+    )
+    mock_appliance.session.send_sync.assert_awaited_once_with(
+        Message(
+            resource="/ro/values",
+            action=Action.POST,
+            data=[{"uid": 109, "value": 100}, {"uid": 108, "value": True}],
+        )
+    )
+    mock_appliance.session.send_sync.reset_mock()


### PR DESCRIPTION
Retargeted from `main` onto `beta` and rebased. **`beta` already fixes most of what this PR originally carried**, so the diff is now much smaller than the description below used to claim.

## What `beta` already has

`beta` independently landed the two `light.py` bugs this branch was opened for — `HCLight.available` no longer AND-s in the attribute entities, and `brightness` / `color_temp_kelvin` / `rgb_color` guard on `value is not None`. Those hunks are dropped; **this PR no longer touches `light.py` at all**. `beta`'s `test_available_when_brightness_unavailable` also supersedes the one this branch added (it covers the round trip back to on), so that duplicate is gone too.

## What's left

`Refrigeration.Common.Setting.Light.Internal` is exposed by the appliance as a `Power` setting plus a `Brightness` setting, and only the `Power` half is wired into the light entity. The internal light is on/off only, and brightness is reachable solely through a separate `number` entity.

- `light_internal` is built by a generator, following `generate_hood_light`, setting `brightness_entity` when the appliance reports both features. Appliances without `Brightness` still get a plain on/off light.
- The standalone brightness `number` is kept, but ships **disabled by default** when a light entity claims brightness — matching how `switch_refrigeration_light_internal` is already handled. An appliance that reports `Brightness` without `Power` still gets the number enabled, since nothing else would control it.
- Carried `beta`'s `step=1` → `native_step=1` fix into the generator (`step` is a type-override field on `NumberEntityDescription` and does nothing).

## Testing

- `test_internal_light` / `test_internal_light_brightness` for the generators.
- `test_turn_on_when_brightness_has_no_value` — turning on while the appliance reports no brightness value. This one is now a guard against regression rather than a failing repro, since `beta` already fixed the underlying `TypeError`.

Full suite on this branch: 137 passed. `ruff check` clean apart from two pre-existing findings on `beta` (`entity.py` BLE001, `tests/__init__.py` RUF100).

Verified on real hardware (Bosch B36CL80ENS, HA 2026.8.2): `off → turn_on 60% → on`, then 100/70/40/15/50% in sequence with the power setting never disturbed.

---

The original, larger version of this change is also open against `chris-mc1/homeconnect_local_hass` as [#448](https://github.com/chris-mc1/homeconnect_local_hass/pull/448), where the `light.py` fixes are still needed.
