### PR TITLE
Await `_set_value_or_raise` in `set_start_in` and `set_finish_in`

### DIFF
--- a/custom_components/homeconnect_ws/__init__.py
+++ b/custom_components/homeconnect_ws/__init__.py
@@ -147,7 +147,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def handle_set_start_in(call: ServiceCall) -> ServiceResponse:
         config_entry = await get_config_entry_from_call(hass, call)
         appliance = config_entry.runtime_data.appliance
-        _set_value_or_raise(
+        await _set_value_or_raise(
             _get_entity_or_raise(
                 appliance, "BSH.Common.Option.StartInRelative", "start_in_not_available"
             ),
@@ -158,7 +158,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def handle_set_finish_in(call: ServiceCall) -> ServiceResponse:
         config_entry = await get_config_entry_from_call(hass, call)
         appliance = config_entry.runtime_data.appliance
-        _set_value_or_raise(
+        await _set_value_or_raise(
             _get_entity_or_raise(
                 appliance, "BSH.Common.Option.FinishInRelative", "finish_in_not_available"
             ),


### PR DESCRIPTION
`handle_set_start_in` and `handle_set_finish_in` call the async helper
`_set_value_or_raise` without awaiting it. The coroutine is created and
immediately discarded: the service call returns successfully, nothing is sent to
the appliance, and a `CodeResponsError` raised by the appliance is swallowed.

### How it shows up

On a Bosch HNG6764B6 oven, `homeconnect_ws.set_finish_in` reported success while
`sensor.*_remaining_program_time` never changed. Nothing appeared in the debug
log either, because the message was never built.

With the `await` in place the same call surfaces the appliance's actual answer —
for this model `403` on `/ro/values`, since it does not allow changing options of
a running program. That is a different discussion, but at least it is now
visible instead of silently succeeding.

### Change

Two `await` keywords. No behaviour change beyond errors now propagating as
intended.
