### PR TITLE
Send a complete option set and use `/ro/activeProgram` for `selectandstart` programs

### DIFF
--- a/custom_components/homeconnect_ws/select.py
+++ b/custom_components/homeconnect_ws/select.py
@@ -11,8 +11,9 @@ from .entity import HCEntity
 from .helpers import create_entities, entity_is_available, error_decorator
 
 if TYPE_CHECKING:
+    from home_disconnect.appliance import HomeAppliance
     from home_disconnect.entities import Entity as HcEntity
-    from home_disconnect.entities import SelectedProgram
+    from home_disconnect.entities import Option, Program, SelectedProgram
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -189,7 +190,15 @@ class HCProgram(HCSelect):
     @error_decorator
     async def async_select_option(self, option: str) -> None:
         selected_program = self._runtime_data.appliance.programs[self._rev_programs[option]]
-        if selected_program.execution in (Execution.SELECT_ONLY, Execution.SELECT_AND_START):
+        if _needs_full_option_set(selected_program):
+            # This appliance validates a program write against the program's
+            # complete option set and rejects anything less with a 400, so
+            # neither of the branches below can apply to it (confirmed live on
+            # a Bosch HNG6764B6 oven, where every single one of its programs
+            # failed to select). Scoped to appliances that actually say so in
+            # their device description - see _needs_full_option_set.
+            await self._select_with_full_option_set(selected_program)
+        elif selected_program.execution in (Execution.SELECT_ONLY, Execution.SELECT_AND_START):
             # override_options=True (send no options) rather than merging in
             # each option's current shared value: a single option UID can have
             # a different valid range depending on which program last set it
@@ -205,3 +214,64 @@ class HCProgram(HCSelect):
             await selected_program.select(override_options=True)
         elif selected_program.execution == Execution.START_ONLY:
             await selected_program.start()
+
+    async def _select_with_full_option_set(self, program: Program) -> None:
+        """Write program and options together, for appliances that demand both."""
+        options = self._build_option_set(program)
+        if program.execution == Execution.SELECT_ONLY:
+            await program.select(options, override_options=True)
+        else:
+            # SELECT_AND_START and START_ONLY both go to /ro/activeProgram: an
+            # appliance that combines selecting and starting into a single
+            # operation rejects a bare POST to /ro/selectedProgram with a 400.
+            await program.start(options, override_options=True)
+
+    def _build_option_set(self, program: Program) -> dict[int, str | int | bool]:
+        """
+        Collect a complete, well-formed option set for a program write.
+
+        The library derives the option list from each option's value_shadow, which
+        stays None until the appliance has reported a value. An appliance that wants
+        a full option set rejects the resulting {"uid": x, "value": None} entries, so
+        fall back to the current value and finally to the option's minimum. Options
+        that stay valueless even then are left out rather than sent as null.
+        """
+        options: dict[int, str | int | bool] = {}
+        for opt in program._options:  # noqa: SLF001
+            if opt.access != Access.READ_WRITE:
+                continue
+            if _is_unplugged_probe(self._runtime_data.appliance, opt):
+                continue
+            value = opt.value_shadow
+            if value is None:
+                value = opt.value
+            if value is None:
+                value = opt.min
+            if value is None:
+                continue
+            options[opt.uid] = value
+        return options
+
+
+def _needs_full_option_set(program: Program) -> bool:
+    """
+    Whether this appliance expects program and options as one complete write.
+
+    Comes from the fullOptionSet flag in the device description. home_disconnect
+    parses it into EntityDescription but does not expose it on Program yet, so
+    this stays False - and every appliance keeps its current behaviour - until it
+    does.
+    """
+    return bool(getattr(program, "full_option_set", False))
+
+
+def _is_unplugged_probe(appliance: HomeAppliance, option: Option) -> bool:
+    """
+    Whether option is a meat probe setpoint while no probe is plugged in.
+
+    Supplying it anyway makes the appliance reject the entire program write.
+    """
+    if "MeatProbeTemperature" not in option.name:
+        return False
+    plugged = appliance.status.get("Cooking.Oven.Status.MeatprobePlugged")
+    return not bool(getattr(plugged, "value", False))

--- a/custom_components/homeconnect_ws/select.py
+++ b/custom_components/homeconnect_ws/select.py
@@ -245,8 +245,10 @@ class HCProgram(HCSelect):
             value = opt.value_shadow
             if value is None:
                 value = opt.value
-            if value is None:
-                value = opt.min
+            if value is None and opt.min is not None:
+                # opt.min is typed float (generic XML min/max parsing), but the
+                # wire protocol only ever takes int/str/bool option values.
+                value = int(opt.min)
             if value is None:
                 continue
             options[opt.uid] = value

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from custom_components.homeconnect_ws import HCData
 from custom_components.homeconnect_ws.entity_descriptions.descriptions_definitions import (
     HCSelectEntityDescription,
 )
 from custom_components.homeconnect_ws.select import HCSelect
-from home_disconnect.entities import Access, Execution
+from home_disconnect.entities import Access, Execution, Program
 from home_disconnect.message import Action, Message
 from homeassistant.components.select import (
     ATTR_OPTION,
@@ -343,6 +343,83 @@ async def test_start_only_program_sends_known_option_values(
             data={
                 "program": 502,
                 "options": [{"uid": 401, "value": 1}, {"uid": 402, "value": None}],
+            },
+        )
+    )
+
+
+async def test_full_option_set_program_sends_complete_options(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,
+) -> None:
+    """
+    An appliance advertising fullOptionSet gets program and options in one write.
+
+    Confirmed live on a Bosch HNG6764B6 oven: it marks its SelectedProgram
+    fullOptionSet, and rejects both a bare POST to /ro/selectedProgram and an
+    option sent as null - every one of its programs failed to select with a
+    400. Test.Option2 has no value anywhere, so it is left out of the write
+    entirely rather than sent as null.
+    """
+    entity_id = "select.fake_brand_homeappliance_selectedprogram"
+    await mock_appliance.entities["Test.Option1"].update({"value": 1})
+    assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
+
+    with patch.object(Program, "full_option_set", new=True, create=True):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_OPTION: "test_program_program2",
+            },
+            blocking=True,
+        )
+
+    mock_appliance.session.send_sync.assert_awaited_once_with(
+        Message(
+            resource="/ro/activeProgram",
+            action=Action.POST,
+            data={
+                "program": 501,
+                "options": [{"uid": 401, "value": 1}],
+            },
+        )
+    )
+
+
+async def test_full_option_set_select_only_program_stays_on_selected_program(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,
+) -> None:
+    """A select-only program keeps /ro/selectedProgram, but carries its options."""
+    entity_id = "select.fake_brand_homeappliance_selectedprogram"
+    await mock_appliance.entities["Test.Option1"].update({"value": 1})
+    await mock_appliance.programs["Test.Program.Program2"].update(
+        {"execution": Execution.SELECT_ONLY}
+    )
+    assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
+
+    with patch.object(Program, "full_option_set", new=True, create=True):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_OPTION: "test_program_program2",
+            },
+            blocking=True,
+        )
+
+    mock_appliance.session.send_sync.assert_awaited_once_with(
+        Message(
+            resource="/ro/selectedProgram",
+            action=Action.POST,
+            data={
+                "program": 501,
+                "options": [{"uid": 401, "value": 1}],
             },
         )
     )


### PR DESCRIPTION
Selecting any program on a Bosch HNG6764B6 oven fails with `400 BadRequest`.
Fifteen heating modes, five microwave modes and the combi modes all behave the
same, so it is not program specific.

### Cause 1 — wrong resource

The device description marks the programs as `execution: "selectandstart"` and
`BSH.Common.Root.SelectedProgram` as `fullOptionSet: true`. This appliance
expects program, options and start as a single write to `/ro/activeProgram`;
a bare POST to `/ro/selectedProgram` is rejected.

`async_select_option` currently groups `SELECT_ONLY` and `SELECT_AND_START`
together and calls `select()` for both.

### Cause 2 — options without a value

`Program._build_options()` derives the option list from each option's
`value_shadow`, which stays `None` until the appliance has reported a value. On
an appliance that has never had a program selected, the write therefore contains
`{"uid": x, "value": null}` for every read-write option.

Captured from the websocket log:

```json
{"resource":"/ro/selectedProgram","action":"POST","data":[{"program":8208,
 "options":[{"uid":5121,"value":null},{"uid":5120,"value":null}, ...]}]}
```

### Cause 3 — the meat probe

After filling in the missing values the write was still rejected. The reason is
`Cooking.Oven.Option.MeatProbeTemperature`: supplying it while no probe is
plugged in invalidates the entire write. Omitting that single option is what
finally made it work.

### Result

```
POST /ro/activeProgram  program 8208
options: 5120=200, 548=720, 5123=false, 5125=0, 558=0     -> accepted
operation_state = run, hot air, 200 °C
```

### Notes for review

Verified on one appliance only (HNG6764B6, SW 2.17.1.13549). The fallback chain
`value_shadow → value → min` is a heuristic; for a program that requires a
temperature this yields the lowest legal setpoint rather than the program's own
`default`, which the library discards at parse time in `Program.__init__` (only
`refUID` is kept from the option description). Preserving that `default` would be
the cleaner fix and probably belongs in `home-disconnect` rather than here.

`_is_unplugged_probe` is oven specific by name matching. Happy to generalise it
if you prefer a different mechanism.
