### PR TITLE
Added IP address to device info.

### DIFF
--- a/custom_components/homeconnect_ws/__init__.py
+++ b/custom_components/homeconnect_ws/__init__.py
@@ -189,7 +189,7 @@ async def async_setup_entry(
         hw_version=appliance.info.get("hwVersion"),
         identifiers={(DOMAIN, config_entry.unique_id)},
         model=f"{appliance.info.get('type')}",
-        model_id=appliance.info.get("vib"),
+        model_id=f"{appliance.info.get('vib')} / IP: {appliance.session._host}",
         sw_version=appliance.info.get("swVersion"),
     )
 

--- a/custom_components/homeconnect_ws/__init__.py
+++ b/custom_components/homeconnect_ws/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Never
 import voluptuous as vol
 from home_disconnect import CodeResponsError, Entity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_DESCRIPTION, EVENT_HOMEASSISTANT_STOP, CONF_HOST
+from homeassistant.const import CONF_DESCRIPTION, CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.exceptions import ConfigEntryError, ServiceValidationError
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,

--- a/custom_components/homeconnect_ws/__init__.py
+++ b/custom_components/homeconnect_ws/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Never
 import voluptuous as vol
 from home_disconnect import CodeResponsError, Entity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_DESCRIPTION, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_DESCRIPTION, EVENT_HOMEASSISTANT_STOP, CONF_HOST
 from homeassistant.exceptions import ConfigEntryError, ServiceValidationError
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
@@ -189,7 +189,7 @@ async def async_setup_entry(
         hw_version=appliance.info.get("hwVersion"),
         identifiers={(DOMAIN, config_entry.unique_id)},
         model=f"{appliance.info.get('type')}",
-        model_id=f"{appliance.info.get('vib')} / IP: {appliance.session._host}",
+        model_id=f"{appliance.info.get('vib')} / IP: {config_entry.data[CONF_HOST]}",
         sw_version=appliance.info.get("swVersion"),
     )
 


### PR DESCRIPTION
## Description

This PR adds the IP address information to the device info page (see screenshot).
I am often looking up the IP in my DHCP configs. having it here allows to quickly identify the correct device in the logs.

<img width="248" height="146" alt="grafik" src="https://github.com/user-attachments/assets/128e54a9-5843-4fad-aada-775f6fceca4e" />

## Checklist

- [X] This has been tested against a real appliance
- [X] If this adds/changes an entity: the `icons.json` file has been updated
- [X] If this adds/changes an entity: the `translations/en.json` `strings.json`file had been updated (the reference locale — other languages are welcome but not required, a maintainer can fill those in)
- [X] If this adds a new user-facing entity/feature: the [docs/integration/supported-functions.md](../docs/integration/supported-functions.md) had been updated
- [X] If this changes how entity descriptions work: the [docs/development/entity_descriptions.md](../docs/development/entity_descriptions.md) had been updated
