### PR TITLE
fix(fan): derive hood `is_on` from `OperationState` instead of a stale active program

### DIFF
--- a/custom_components/homeconnect_ws/fan.py
+++ b/custom_components/homeconnect_ws/fan.py
@@ -46,9 +46,12 @@ async def async_setup_entry(
     async_add_entites(entities)
 
 
+_OPERATION_STATE_ENTITY = "BSH.Common.Status.OperationState"
+_INACTIVE_OPERATION_STATES = frozenset({"inactive", "ready"})
+
 _HOOD_FAN_STATE_ENTITIES = (
     "BSH.Common.Root.ActiveProgram",
-    "BSH.Common.Status.OperationState",
+    _OPERATION_STATE_ENTITY,
 )
 
 
@@ -106,7 +109,17 @@ class HCFan(HCEntity, FanEntity):
 
     @property
     def is_on(self) -> bool:
-        if self._runtime_data.appliance.active_program is None:
+        appliance = self._runtime_data.appliance
+        # Some hoods keep reporting an active Venting program with a non-zero
+        # venting level after being switched off. OperationState is the
+        # authoritative signal in that case.
+        operation_state = appliance.entities.get(_OPERATION_STATE_ENTITY)
+        if (
+            operation_state is not None
+            and str(operation_state.value or "").lower() in _INACTIVE_OPERATION_STATES
+        ):
+            return False
+        if appliance.active_program is None:
             return False
         return any(entity.value_raw not in (None, 0) for entity in self._speed_entities.values())
 


### PR DESCRIPTION
Closes #60.

Sure, I'll open a PR — tested on `beta`, results below.

Upfront disclosure: the diagnosis and the patch were produced with Claude (Anthropic's AI) working directly against my live installation — it read the appliance profile, compared the two `is_on` implementations, wrote the patch and ran the before/after test. I reviewed it and verified the results myself. Flagging it because you're the one who'll have to maintain this, and you don't have a hood to check it against.

**Tested against `beta`, not the 1.7.0 tag**

I re-tested on `beta` as of 2026-08-30 — so *with* your `DELETE /ro/activeProgram` fix and `home-disconnect 1.7.0b0` — to make sure this wasn't already covered by your recent work. It isn't:

| | before patch | after patch |
|---|---|---|
| `fan.<hood>` | **on**, 100 % | **off**, 0 % |
| `sensor.<hood>_power_state` | off | off |
| `sensor.<hood>_operation_state` | inactive | inactive |
| `sensor.<hood>_active_program` | `..._hood_venting` | `..._hood_venting` |
| `binary_sensor.<hood>_connection` | on | on |

`active_program` stays on Venting in both columns — that's the appliance, not the integration, and it's exactly why `is_on` needs a second signal.

**This is complementary to your `DELETE` fix, not a duplicate.** My hood was switched off *at the appliance*, so HA never sent a stop command and there was nothing for `async_turn_off` to correct. Your fix makes HA-initiated stops work; this one makes the reported state correct regardless of how the hood was stopped.

**The change**

`OperationState` is already listed in `_HOOD_FAN_STATE_ENTITIES`, so the entity is subscribed to — it just isn't consulted in `is_on`. The patch gates on it before falling through to the existing logic:

```python
_OPERATION_STATE_ENTITY = "BSH.Common.Status.OperationState"
_INACTIVE_OPERATION_STATES = frozenset({"inactive", "ready"})

_HOOD_FAN_STATE_ENTITIES = (
    "BSH.Common.Root.ActiveProgram",
    _OPERATION_STATE_ENTITY,
)


@property
def is_on(self) -> bool:
    appliance = self._runtime_data.appliance
    # Some hoods keep reporting an active Venting program with a non-zero
    # venting level after being switched off. OperationState is the
    # authoritative signal in that case.
    operation_state = appliance.entities.get(_OPERATION_STATE_ENTITY)
    if (
        operation_state is not None
        and str(operation_state.value or "").lower() in _INACTIVE_OPERATION_STATES
    ):
        return False
    if appliance.active_program is None:
        return False
    return any(entity.value_raw not in (None, 0) for entity in self._speed_entities.values())
```

**Why it should be safe for appliances that aren't affected**

- Skipped entirely when the appliance doesn't expose `OperationState` (`.get()` returns `None`) — no change for those.
- When `OperationState` is `Run`, the existing `active_program` / venting-level logic decides exactly as before.
- It only short-circuits on `inactive` / `ready`, the two states in which a hood cannot be extracting air. My hood's enum is `['inactive', 'run']`; `ready` is included because other appliance classes use it, and the pre-fork upstream implementation treated both as off.
- `str(... or "").lower()` matches the normalisation already used in `sensor.py` for enum values.

**No regression observed**

48 live entities across hood + dishwasher, dishwasher still reporting `run` mid-cycle, the four filter-reset buttons present, nothing from this integration in the error log.

Happy to provide a full profile dump or a WebSocket trace across an on/off cycle if you want to see the raw messages.
