### PR TITLE
fix(fan): send the full option set when starting a hood venting program

### DIFF
--- a/custom_components/homeconnect_ws/fan.py
+++ b/custom_components/homeconnect_ws/fan.py
@@ -14,7 +14,13 @@ from homeassistant.util.percentage import percentage_to_ranged_value, ranged_val
 
 from .const import DOMAIN
 from .entity import HCEntity
-from .helpers import create_entities, entity_is_available, error_decorator
+from .helpers import (
+    build_full_option_set,
+    create_entities,
+    entity_is_available,
+    error_decorator,
+    needs_full_option_set,
+)
 
 if TYPE_CHECKING:
     from home_disconnect.entities import Entity as HcEntity
@@ -194,7 +200,17 @@ class HCFan(HCEntity, FanEntity):
         **kwargs: Any,
     ) -> None:
         if percentage is None:
-            await self._venting_program().start(options={}, override_options=True)
+            program = self._venting_program()
+            # Same 400 BadRequest as the start button / program select: an
+            # appliance whose ActiveProgram is flagged fullOptionSet validates
+            # a program write against the program's complete option set and
+            # rejects an empty one. Confirmed live on a Bosch hood.
+            options = (
+                build_full_option_set(self._runtime_data.appliance, program)
+                if needs_full_option_set(program)
+                else {}
+            )
+            await program.start(options, override_options=True)
         else:
             await self.async_set_percentage(int(percentage))
         self.async_write_ha_state()


### PR DESCRIPTION
Second small fix from the same Bosch hood (`DWK81AN60/05`, swVersion 5.19.0.11), independent of the `is_on` PR — they touch different methods and can be merged in either order.

Same disclosure as the other one: diagnosed and patched with Claude (Anthropic's AI) against my live installation; I reviewed it and tested the result myself.

**Problem**

Pressing the fan's power button raised:

```
Error response from Appliance: 400 BadRequest
```

`async_turn_on` starts the venting program with `options={}`:

```python
await self._venting_program().start(options={}, override_options=True)
```

This appliance's `ActiveProgram` is flagged `fullOptionSet`, so it validates a program write against the program's *complete* option set and rejects an empty one.

**Why the fix is already in the codebase**

This is the exact case `needs_full_option_set()` / `build_full_option_set()` were written for — they're already applied to the start button and the program select. The fan path just wasn't using them. The patch reuses them rather than adding anything new:

```python
if percentage is None:
    program = self._venting_program()
    options = (
        build_full_option_set(self._runtime_data.appliance, program)
        if needs_full_option_set(program)
        else {}
    )
    await program.start(options, override_options=True)
```

Appliances not flagged `fullOptionSet` keep the previous `{}` behaviour exactly.

**Tested**

WebSocket capture after the patch, hood switching on normally:

```
Send     POST /ro/activeProgram {"program":55307,"options":[{"uid":55308,"value":2},{"uid":55305,"value":0}]}
Received RESPONSE                                    (0.36 s)
Received NOTIFY [{"uid":539,"value":2}]              PowerState = On
```

No more 400, and the two options the appliance expects are now present.
