### PR TITLE
fix(fan): stop hoods by writing `PowerState`, not by deleting the active program

### DIFF
--- a/custom_components/homeconnect_ws/fan.py
+++ b/custom_components/homeconnect_ws/fan.py
@@ -6,14 +6,13 @@ import math
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from home_disconnect.entities import Access
-from home_disconnect.message import Action
-from home_disconnect.message import Message as HC_Message
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util.percentage import percentage_to_ranged_value, ranged_value_to_percentage
 
 from .const import DOMAIN
 from .entity import HCEntity
+from .entity_descriptions.common import POWER_OFF_STATE_NAMES
 from .helpers import create_entities, entity_is_available, error_decorator
 
 if TYPE_CHECKING:
@@ -45,6 +44,8 @@ async def async_setup_entry(
     entities = create_entities({"fan": HCFan}, config_entry.runtime_data)
     async_add_entites(entities)
 
+
+_POWER_STATE_ENTITY = "BSH.Common.Setting.PowerState"
 
 _HOOD_FAN_STATE_ENTITIES = (
     "BSH.Common.Root.ActiveProgram",
@@ -205,11 +206,31 @@ class HCFan(HCEntity, FanEntity):
         if appliance.active_program is None:
             return
 
-        # Writing 0 to the speed options (the previous approach) is rejected
-        # by some hoods - confirmed live via debug log (fork issue #17): the
-        # appliance's confirmation echoes the option back at its old,
-        # non-zero value instead of accepting 0. Deleting the active program
-        # is the correct way to stop it, matching upstream issue #386.
-        message = HC_Message(resource="/ro/activeProgram", action=Action.DELETE, data=[])
-        await appliance.session.send_sync(message)
+        # A hood has no way to abort a running program: it exposes no
+        # AbortProgram command and its programs are all START_ONLY. Both
+        # other candidates are dead ends, confirmed live on a DWK81AN60 by
+        # reading the WebSocket debug log:
+        #   - DELETE /ro/activeProgram is never answered at all, so send_sync
+        #     waits for a response that cannot come and raises TimeoutError
+        #     (upstream issue #386 describes it working on other appliance
+        #     classes, so this stays appliance-specific).
+        #   - re-POSTing the venting program with VentingLevel=FanOff gets a
+        #     bare RESPONSE and is then silently dropped: no value notify
+        #     follows and the fan keeps spinning at its previous stage
+        #     (fork issue #17).
+        # Powering the appliance off is the only stop it honours, and it is
+        # the exact counterpart of starting a program, which the hood answers
+        # by switching PowerState to On by itself.
+        power_state = appliance.entities.get(_POWER_STATE_ENTITY)
+        off_value = None
+        if power_state is not None:
+            settable = set((power_state.enum or {}).values())
+            off_value = next((n for n in POWER_OFF_STATE_NAMES if n in settable), None)
+        if off_value is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="no_power_off",
+            )
+
+        await power_state.set_value(off_value)
         self.async_write_ha_state()

--- a/custom_components/homeconnect_ws/helpers.py
+++ b/custom_components/homeconnect_ws/helpers.py
@@ -187,5 +187,15 @@ def error_decorator[T](
                 translation_domain=DOMAIN,
                 translation_key="not_connected",
             ) from None
+        except TimeoutError:
+            # send_sync waits on a response queue that stays empty when the
+            # appliance never answers a message (an action it does not
+            # implement, or a connection that dropped mid-request). Without
+            # this the bare asyncio TimeoutError reaches the frontend as an
+            # opaque "unknown error".
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_timeout",
+            ) from None
 
     return wrap

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -4062,6 +4062,12 @@
     },
     "not_connected": {
       "message": "Client is not Connected"
+    },
+    "no_power_off": {
+      "message": "This appliance cannot be switched off remotely, so the fan cannot be stopped"
+    },
+    "command_timeout": {
+      "message": "The appliance did not answer the command in time"
     }
   }
 }


### PR DESCRIPTION
I'm the one who proposed `DELETE /ro/activeProgram` in the first place — upstream chris-mc1#386, back in May — and this fork adopted it. I was wrong, and I have the traces to show it: my hood (a Bosch `DWK81AN60/05`) never answers that message, so `send_sync` waits for a response that cannot come and raises `TimeoutError`. chris-mc1 reached the same conclusion from the other end ("DELETE is not a valid action for the websocket api", chris-mc1#387). Here is what the appliance actually expects instead.

Same disclosure as my previous reports: the captures and the analysis were produced with Claude (Anthropic's AI) against my live installation. I read every trace myself before writing this.

## What changes

`HCFan.async_turn_off` stops sending `DELETE /ro/activeProgram` and writes `BSH.Common.Setting.PowerState` to its off value instead. The off value is resolved through the existing `POWER_OFF_STATE_NAMES` tuple in `entity_descriptions/common.py`, so models that name it `MainsOff` rather than `Off` are handled, and an appliance exposing neither raises a `ServiceValidationError` instead of failing opaquely.

The fan platform only ever backs hoods, so the change is scoped to hoods and cannot affect other appliance classes — which may or may not honour `DELETE`; #386 was my own proposal and I never verified it beyond this hood.

Two small things ride along:

- `error_decorator` now catches `TimeoutError` (new `command_timeout` key). `send_sync` waits on a response queue that stays empty whenever an appliance doesn't answer a message; without this the bare `asyncio.TimeoutError` reaches the frontend as `{'code': 'unknown_error', 'message': ''}`, which is what made the original bug so hard to place.
- Dead `Action` / `Message` imports removed from `fan.py`.

## Why `PowerState`, and not a program abort

The short version: **this hood has no program abort, and Bosch's own software doesn't use one either.**

The appliance's own description advertises no `BSH.Common.Command.AbortProgram` — the full command list is `AcknowledgeEvent`, `RejectEvent`, `AllowSoftwareUpdate`, `AllowSoftwareDownload`, `ApplyFactoryReset`, `ApplyNetworkReset` and the four filter resets. All four hood programs are `execution: startonly`.

I captured the WebSocket frames for three independent ways of stopping the same hood. All three do the same thing:

| Stop initiated from | Frames observed |
|---|---|
| This integration (the fix) | `POST /ro/values [{"uid":539,"value":1}]` → `RESPONSE` → `NOTIFY 539=1` |
| The official Home Connect app | `539 → Off` first, fan follows 168 ms later |
| **The hood's own physical buttons** | `539 → Off`, then `552 → 0`, then lighting off. Nothing else. |

That third row is the one that settles it. Pressing Off on the appliance's own control panel emits **no** `VentingLevel = 0` and **no** clearing of `ActiveProgram` (uid 256) — the hood simply goes to standby with its program still nominally active. There is no hidden mechanism we're failing to reach; the appliance doesn't have one.

Conversely, starting a program on the hardware buttons emits `VentingLevel`, then `ActiveProgram`, then `OperationState = Run`, and only **1.4 s later** `PowerState = On`. Program start leads, power state follows. Writing `PowerState = Off` to stop is the exact counterpart of that, which is why it reads as the natural inverse of `async_turn_on`.

## About the `VentingLevel = FanOff` route

The current code comment says writing 0 to the speed options is "rejected by some hoods … the appliance's confirmation echoes the option back at its old, non-zero value". On this model it's quieter than that, and worth correcting in the record:

```
Send     POST /ro/activeProgram {"program":55307,"options":[{"uid":55308,"value":0},{"uid":55305,"value":0}]}
Received RESPONSE
         <- nothing. No value notify at all. Fan keeps running at its previous stage.
```

A bare accept, then silence. And in the physical-button capture, the hood walks its level down 4 → 3 → 1 and then goes to standby — it **never emits `VentingLevel = 0` itself**, despite `0: FanOff` being in the enumeration it publishes. It looks like a phantom value on this model, which would explain the polite acknowledgement followed by nothing.

## Side effects worth knowing

**The appliance light goes off with the hood.** Unavoidable — powering down is powering down, and it's what the physical Off button does too. It is recoverable, though: I verified that `Cooking.Common.Setting.Lighting` still accepts writes while `PowerState` is `Off`, so a user who wants the light to survive can turn it straight back on without waking the fan. (The hood also has `Cooking.Hood.Setting.WorkingLightShutdownSetting` with a `KeepLightOn` value, which the integration doesn't currently surface as an entity — possibly worth exposing separately.)

**This also removes a source of connection churn.** The `DELETE` didn't just time out, it made the hood drop the socket with close code 1006 every time. Each failed `turn_off` therefore took every entity of the appliance `unavailable` for about a second during the reconnect. On my install that re-armed a `numeric_state` trigger and produced spurious alerts. With the `DELETE` gone, those disconnects go with it.

## If you'd rather not take it as-is

Reasonable alternatives, your call — I went with the direct route because all three reference implementations agree on it:

1. Try `DELETE` first and fall back to `PowerState` on timeout. Robust but slow, and it keeps the 1006 disconnect on every stop.
2. Gate on a detected capability rather than on the platform.
3. Keep `DELETE` for appliance classes where it's confirmed working and use `PowerState` only for hoods — which is effectively what this PR does, since the fan platform is hood-only.

Happy to run any capture you want against the hood.
