### PR TITLE
Reconfigure flow

### DIFF
--- a/custom_components/homeconnect_ws/config_flow.py
+++ b/custom_components/homeconnect_ws/config_flow.py
@@ -97,12 +97,6 @@ CONFIG_HOST_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): cv.string,
     }
 )
-RECONFIGURE_CONNECTION_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_MANUAL_HOST): cv.boolean,
-        vol.Required(CONF_HOST): cv.string,
-    }
-)
 REGION_LABELS = {"EU": "Europe", "NA": "North America", "CN": "China"}
 CONFIG_REGION_SCHEMA = vol.Schema(
     {
@@ -254,6 +248,11 @@ class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(
                     reason="oauth_fetch_failed", description_placeholders={"error": str(err)}
                 )
+            if self.unique_id:
+                # Reauth/reconfigure already know which Appliance this is -
+                # device_select is for picking a *new* one and would filter
+                # this one out as already configured.
+                return await self.async_step_set_data()
             return await self.async_step_device_select()
 
         authorize_url = legacy_build_authorize_url(
@@ -464,68 +463,54 @@ class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
             menu_options=["reconfigure_connection", "reconfigure_profile"],
         )
 
+    def _auto_host(self) -> str:
+        """Derive this Appliance's mDNS-resolvable name, the same way initial setup does."""
+        info = self.data[CONF_DESCRIPTION]["info"]
+        if self.data[CONF_MODE] == "TLS":
+            return f"{info['brand']}-{info['type']}-{info['deviceID']}"
+        return cast("str", info["deviceID"])
+
     async def async_step_reconfigure_connection(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Switch between automatic (mDNS) discovery and a fixed IP address."""
-        reconfigure_entry = self._get_reconfigure_entry()
-        if user_input is not None:
-            self.data = deepcopy(dict(reconfigure_entry.data))
-            self.data[CONF_MANUAL_HOST] = user_input[CONF_MANUAL_HOST]
-            self.data[CONF_HOST] = user_input[CONF_HOST]
-            return await self.async_step_test_connection()
+        """
+        Switch between automatic (mDNS) discovery and a fixed IP address.
 
-        schema = self.add_suggested_values_to_schema(
-            RECONFIGURE_CONNECTION_SCHEMA,
-            {
-                CONF_MANUAL_HOST: reconfigure_entry.data.get(CONF_MANUAL_HOST, False),
-                CONF_HOST: reconfigure_entry.data[CONF_HOST],
-            },
-        )
-        return self.async_show_form(
-            step_id="reconfigure_connection", data_schema=schema, errors=self.errors
-        )
+        Tries automatic discovery first and only asks for a fixed IP-Address
+        on failure, exactly like initial setup - async_step_test_connection
+        already falls back to async_step_host for that. There's deliberately
+        no "manual anyway, even though automatic would work" option here,
+        matching initial setup's own behavior.
+        """
+        reconfigure_entry = self._get_reconfigure_entry()
+        self.data = deepcopy(dict(reconfigure_entry.data))
+        self.data[CONF_MANUAL_HOST] = False
+        self.data[CONF_HOST] = self._auto_host()
+        return await self.async_step_test_connection()
 
     async def async_step_reconfigure_profile(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """
-        Re-upload a profile file to refresh this Appliance's description and keys.
+        Refresh this Appliance's profile via a new upload or a fresh Home Connect sign-in.
 
         Covers two cases a fresh upload but not a full migration can't: new
         Options/Settings a firmware update added (only present in a newly
         exported profile file) and a new encryption key after the Appliance
         was unpaired and re-paired with Home Connect.
+
+        Reuses the same legacy_oauth_region/upload steps initial setup and
+        reauth use, rather than a bespoke upload-only form - so a user who
+        set up via Home Connect sign-in isn't forced to find their old
+        profile-download file just to refresh it.
         """
         reconfigure_entry = self._get_reconfigure_entry()
-        if user_input is not None:
-            try:
-                appliances = await self.hass.async_add_executor_job(
-                    self._process_profile_file, user_input[CONF_FILE]
-                )
-            except ParserError as exc:
-                return self.async_abort(
-                    reason="profile_file_parser_error",
-                    description_placeholders={"error": exc.args[0]},
-                )
-            except (KeyError, ValueError):
-                return self.async_abort(reason="invalid_profile_file")
-
-            if reconfigure_entry.unique_id not in appliances:
-                return self.async_abort(reason="appliance_not_in_profile_file")
-
-            try:
-                appliance = appliances[reconfigure_entry.unique_id]
-                self.data = deepcopy(dict(reconfigure_entry.data))
-                self.data[CONF_DESCRIPTION] = appliance["description"]
-                self._set_encryption_keys(appliance["info"])
-            except (KeyError, ValueError):
-                return self.async_abort(reason="invalid_profile_file")
-
-            return await self.async_step_test_connection()
-
-        return self.async_show_form(
-            step_id="reconfigure_profile", data_schema=CONFIG_FILE_SCHEMA, errors=self.errors
+        self.global_config = self.hass.data.get(HC_KEY)
+        self.data = deepcopy(dict(reconfigure_entry.data))
+        await self.async_set_unique_id(reconfigure_entry.unique_id)
+        return self.async_show_menu(
+            step_id="reconfigure_profile",
+            menu_options=["legacy_oauth_region", "upload"],
         )
 
     async def async_step_set_data(

--- a/custom_components/homeconnect_ws/config_flow.py
+++ b/custom_components/homeconnect_ws/config_flow.py
@@ -407,6 +407,14 @@ class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
         finally:
             await appliance.close()
         if self.errors:
+            if not self.data.get(CONF_MANUAL_HOST, False):
+                # This attempt used the automatically-guessed mDNS-style
+                # host (initial setup's own guess, or async_step_
+                # reconfigure_connection's), not one the user actually
+                # typed in - say so, rather than implying they entered
+                # something wrong when they haven't been asked for
+                # anything yet.
+                self.errors["base"] = "cannot_connect_automatic"
             _LOGGER.debug("Connection error, showing host step")
             return await self.async_step_host()
         _LOGGER.debug("config vaild, adding config entry")

--- a/custom_components/homeconnect_ws/config_flow.py
+++ b/custom_components/homeconnect_ws/config_flow.py
@@ -28,7 +28,13 @@ from home_disconnect import (
 )
 from homeassistant.components.file_upload import process_uploaded_file
 from homeassistant.components.http.auth import async_sign_path
-from homeassistant.config_entries import SOURCE_IGNORE, ConfigEntryState, ConfigFlow, OptionsFlow
+from homeassistant.config_entries import (
+    SOURCE_IGNORE,
+    SOURCE_RECONFIGURE,
+    ConfigEntryState,
+    ConfigFlow,
+    OptionsFlow,
+)
 from homeassistant.const import (
     CONF_DESCRIPTION,
     CONF_DEVICE,
@@ -88,6 +94,12 @@ CONFIG_FILE_SCHEMA_JSON = vol.Schema(
 )
 CONFIG_HOST_SCHEMA = vol.Schema(
     {
+        vol.Required(CONF_HOST): cv.string,
+    }
+)
+RECONFIGURE_CONNECTION_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_MANUAL_HOST): cv.boolean,
         vol.Required(CONF_HOST): cv.string,
     }
 )
@@ -420,10 +432,15 @@ class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
-        """Create an config entry or update existing entry for reauth."""
+        """Create an config entry or update existing entry for reauth/reconfigure."""
         if self.reauth_entry:
             return self.async_update_reload_and_abort(
                 self.reauth_entry,
+                data_updates=data,
+            )
+        if self.source == SOURCE_RECONFIGURE:
+            return self.async_update_reload_and_abort(
+                self._get_reconfigure_entry(),
                 data_updates=data,
             )
         return self.async_create_entry(title=data[CONF_NAME], data=data)
@@ -436,6 +453,80 @@ class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="reauth_entry_not_found")
         self.data[CONF_HOST] = self.reauth_entry.data[CONF_HOST]
         return await self.async_step_user()
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a reconfigure flow, initiated from the config entry's own menu."""
+        self.global_config = self.hass.data.get(HC_KEY)
+        return self.async_show_menu(
+            step_id="reconfigure",
+            menu_options=["reconfigure_connection", "reconfigure_profile"],
+        )
+
+    async def async_step_reconfigure_connection(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Switch between automatic (mDNS) discovery and a fixed IP address."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        if user_input is not None:
+            self.data = deepcopy(dict(reconfigure_entry.data))
+            self.data[CONF_MANUAL_HOST] = user_input[CONF_MANUAL_HOST]
+            self.data[CONF_HOST] = user_input[CONF_HOST]
+            return await self.async_step_test_connection()
+
+        schema = self.add_suggested_values_to_schema(
+            RECONFIGURE_CONNECTION_SCHEMA,
+            {
+                CONF_MANUAL_HOST: reconfigure_entry.data.get(CONF_MANUAL_HOST, False),
+                CONF_HOST: reconfigure_entry.data[CONF_HOST],
+            },
+        )
+        return self.async_show_form(
+            step_id="reconfigure_connection", data_schema=schema, errors=self.errors
+        )
+
+    async def async_step_reconfigure_profile(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """
+        Re-upload a profile file to refresh this Appliance's description and keys.
+
+        Covers two cases a fresh upload but not a full migration can't: new
+        Options/Settings a firmware update added (only present in a newly
+        exported profile file) and a new encryption key after the Appliance
+        was unpaired and re-paired with Home Connect.
+        """
+        reconfigure_entry = self._get_reconfigure_entry()
+        if user_input is not None:
+            try:
+                appliances = await self.hass.async_add_executor_job(
+                    self._process_profile_file, user_input[CONF_FILE]
+                )
+            except ParserError as exc:
+                return self.async_abort(
+                    reason="profile_file_parser_error",
+                    description_placeholders={"error": exc.args[0]},
+                )
+            except (KeyError, ValueError):
+                return self.async_abort(reason="invalid_profile_file")
+
+            if reconfigure_entry.unique_id not in appliances:
+                return self.async_abort(reason="appliance_not_in_profile_file")
+
+            try:
+                appliance = appliances[reconfigure_entry.unique_id]
+                self.data = deepcopy(dict(reconfigure_entry.data))
+                self.data[CONF_DESCRIPTION] = appliance["description"]
+                self._set_encryption_keys(appliance["info"])
+            except (KeyError, ValueError):
+                return self.async_abort(reason="invalid_profile_file")
+
+            return await self.async_step_test_connection()
+
+        return self.async_show_form(
+            step_id="reconfigure_profile", data_schema=CONFIG_FILE_SCHEMA, errors=self.errors
+        )
 
     async def async_step_set_data(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/homeconnect_ws/quality_scale.yaml
+++ b/custom_components/homeconnect_ws/quality_scale.yaml
@@ -117,9 +117,14 @@ rules:
       quality_scale.yaml: some numeric-range icon logic isn't expressible
       with icons.json's state/range selectors alone.
   reconfiguration-flow:
-    status: exempt
+    status: done
     comment: |
-      No need for reconfiguration flow.
+      Two independent options, since they address unrelated problems: change
+      connection (switch between automatic mDNS discovery and a fixed
+      IP-Address - needed if mDNS isn't reachable on a given network, or to
+      pin/un-pin an Appliance's address) and update profile file (re-upload
+      a profile to pick up new Options/Settings a firmware update added, or
+      a new encryption key after the Appliance was unpaired and re-paired).
   repair-issues:
     status: exempt
     comment: |

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -57,6 +57,7 @@
     },
     "error": {
       "cannot_connect": "Connection to Appliance failed",
+      "cannot_connect_automatic": "Automatic (mDNS) connection failed - enter your Appliance's IP-Address or hostname manually",
       "already_configured": "This Appliance is already configured"
     },
     "abort": {

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -47,19 +47,11 @@
           "reconfigure_profile": "Update Profile File"
         }
       },
-      "reconfigure_connection": {
-        "title": "Change Connection",
-        "description": "By default, this Appliance's address is kept up to date automatically (mDNS). Turn on manual mode if mDNS isn't available on your network, or to pin the Appliance to a fixed IP-Address.",
-        "data": {
-          "manual_host": "Use a fixed IP-Address instead of automatic discovery",
-          "host": "Host / IP-Address"
-        }
-      },
       "reconfigure_profile": {
         "title": "Update Profile File",
-        "description": "Upload a fresh Profile file for this Appliance. Use this after a firmware update added new features, or after unpairing and re-pairing the Appliance with Home Connect (which changes its encryption key).",
-        "data": {
-          "file": "Profile file"
+        "menu_options": {
+          "legacy_oauth_region": "Sign in with Home Connect",
+          "upload": "Upload Profile File"
         }
       }
     },

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -39,6 +39,28 @@
         "data": {
           "host": "Host / IP-Address"
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Appliance",
+        "menu_options": {
+          "reconfigure_connection": "Change Connection",
+          "reconfigure_profile": "Update Profile File"
+        }
+      },
+      "reconfigure_connection": {
+        "title": "Change Connection",
+        "description": "By default, this Appliance's address is kept up to date automatically (mDNS). Turn on manual mode if mDNS isn't available on your network, or to pin the Appliance to a fixed IP-Address.",
+        "data": {
+          "manual_host": "Use a fixed IP-Address instead of automatic discovery",
+          "host": "Host / IP-Address"
+        }
+      },
+      "reconfigure_profile": {
+        "title": "Update Profile File",
+        "description": "Upload a fresh Profile file for this Appliance. Use this after a firmware update added new features, or after unpairing and re-pairing the Appliance with Home Connect (which changes its encryption key).",
+        "data": {
+          "file": "Profile file"
+        }
       }
     },
     "error": {
@@ -48,6 +70,7 @@
     "abort": {
       "auth_failed": "Authentication failed",
       "reauth_successful": "Re-authentication successful",
+      "reconfigure_successful": "Reconfiguration successful",
       "invalid_profile_file": "Profile File is invalid",
       "profile_file_parser_error": "Profile File is invalid: {error}",
       "appliance_not_in_profile_file": "Profile File dose not contain profile for this Appliance",

--- a/docs/integration/other-stuff.md
+++ b/docs/integration/other-stuff.md
@@ -2,8 +2,8 @@
 
 Once an appliance is set up, you can reconfigure it from Settings → Devices & Services → Home Connect Local → the appliance's device page → gear/settings icon → Reconfigure. Two independent options are available:
 
-- **Change Connection**: switch between automatic (mDNS) discovery and a fixed IP-Address. Use this if mDNS isn't reachable on your network, or to pin the appliance to an IP-Address that won't change.
-- **Update Profile File**: re-upload a profile file for this appliance. Use this after a firmware update added new Options/Settings not present in your original profile, or after unpairing and re-pairing the appliance with Home Connect (which changes its encryption key).
+- **Change Connection**: tries automatic (mDNS) discovery first, the same as initial setup, and only asks for a fixed IP-Address if that fails. Use this if mDNS isn't reachable on your network (pins a fixed IP-Address), or to move back to automatic discovery after a network change.
+- **Update Profile File**: refresh this appliance's profile, either by uploading a new profile file or by signing in with Home Connect again - same two options as initial setup. Use this after a firmware update added new Options/Settings not present in your original profile, or after unpairing and re-pairing the appliance with Home Connect (which changes its encryption key).
 
 ## Exporting an Appliance Profile
 

--- a/docs/integration/other-stuff.md
+++ b/docs/integration/other-stuff.md
@@ -1,3 +1,10 @@
+## Reconfiguring an Appliance
+
+Once an appliance is set up, you can reconfigure it from Settings → Devices & Services → Home Connect Local → the appliance's device page → gear/settings icon → Reconfigure. Two independent options are available:
+
+- **Change Connection**: switch between automatic (mDNS) discovery and a fixed IP-Address. Use this if mDNS isn't reachable on your network, or to pin the appliance to an IP-Address that won't change.
+- **Update Profile File**: re-upload a profile file for this appliance. Use this after a firmware update added new Options/Settings not present in your original profile, or after unpairing and re-pairing the appliance with Home Connect (which changes its encryption key).
+
 ## Exporting an Appliance Profile
 
 Once an appliance is set up, you can export its profile from Settings → Devices & Services → Home Connect Local → the appliance's device page → gear/settings icon:

--- a/docs/integration/support-and-troubleshooting.md
+++ b/docs/integration/support-and-troubleshooting.md
@@ -55,13 +55,13 @@ This integration has built in measures (measures not fully tested yet) to preven
 
 Confirmed errors of a websocket shutdown seen so far (there may be others):
 - A plain HTTP 404 on the WebSocket upgrade (`aiohttp.WSServerHandshakeError`) where the appliance's HTTP layer responds normally but rejects the upgrade itself. The cause is understood (unexpected Home Assistant shutdowns leaving half-dead sessions, as described above), and this integration already has a fix/mitigation for it.
-- A TLS handshake reset, which this integration classifies as an authentication failure (`home_disconnect.errors.AuthenticationError`), is a confirmed cause of a shutdown on a washer/dryer combo. The actual cause of this one is still unknown, all that's confirmed is that a power cycle resolves it, not why it happens in the first place. Note that this same exception can also mean a wrong or outdated encryption key, not a websocket shutdown, so before you try the methods below, try deleting the config entry and putiing in a new entry since it would force a new encryption key.
+- A TLS handshake reset, which this integration classifies as an authentication failure (`home_disconnect.errors.AuthenticationError`), is a confirmed cause of a shutdown on a washer/dryer combo. The actual cause of this one is still unknown, all that's confirmed is that a power cycle resolves it, not why it happens in the first place. Note that this same exception can also mean a wrong or outdated encryption key, not a websocket shutdown, so before you try the methods below, try getting a fresh profile file and using the [Update Profile File](other-stuff.md#reconfiguring-an-appliance) reconfigure option, which refreshes the encryption key without needing to remove and re-add the entry.
 
 There are three ways to resolve a websocket shutdown:
 
 1. Disable the cloud: Disabling the cloud (follow the protip section on how to do it), then waiting 24 hours, can allow the device to reopen its local websocket. Note that since you're doing this during a local websocket shutdown, the smart features of the device will be inoperable until the device reopens its websocket. The device will still stay connected to your Wi-Fi.
 2. Power cycle the appliance: Cutting the power from your appliance for 1-5 minutes, then reapplying it, can help resolve the issue.
-3. Re-pair the appliance (not recommended): Resetting the device's network settings and re-pairing it to the Home Connect App resolves the issue. However, doing that is not only time consuming, but you also have to get a new profile file, remove the entry, and re-add it with the new file.
+3. Re-pair the appliance (not recommended): Resetting the device's network settings and re-pairing it to the Home Connect App resolves the issue. However, doing that is time consuming, and you'll need to get a new profile file and apply it via the [Update Profile File](other-stuff.md#reconfiguring-an-appliance) reconfigure option, since re-pairing changes the appliance's encryption key.
 
 ### Reporting Issues and Bugs
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -25,7 +25,7 @@ from home_disconnect.entities import (
     OptionDescription,
 )
 from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.const import CONF_DESCRIPTION, CONF_DEVICE_ID, CONF_HOST, CONF_NAME
+from homeassistant.const import CONF_DESCRIPTION, CONF_DEVICE_ID, CONF_HOST, CONF_MODE, CONF_NAME
 
 MOCK_APPLIANCE_INFO = {
     "brand": "Fake_Brand",
@@ -44,6 +44,7 @@ MOCK_TLS_DEVICE_ID_2 = "102030405060708090"
 MOCK_TLS_DEVICE_DESCRIPTION = {"info": {}, "MOCK_TLS_DEVICE_DESCRIPTION": None}
 MOCK_TLS_DEVICE_INFO = {
     "haId": MOCK_TLS_DEVICE_ID,
+    "deviceID": MOCK_TLS_DEVICE_ID,
     "type": "Test_TLS",
     "serialNumber": MOCK_TLS_DEVICE_ID,
     "brand": "Test_Brand",
@@ -61,6 +62,7 @@ MOCK_AES_DEVICE_ID = "101112131415161718"
 MOCK_AES_DEVICE_DESCRIPTION = {"info": {}, "MOCK_AES_DEVICE_DESCRIPTION": None}
 MOCK_AES_DEVICE_INFO = {
     "haId": MOCK_AES_DEVICE_ID,
+    "deviceID": MOCK_AES_DEVICE_ID,
     "type": "Test_AES",
     "serialNumber": MOCK_AES_DEVICE_ID,
     "brand": "Test_Brand",
@@ -525,6 +527,7 @@ DEVICE_DESCRIPTION = DeviceDescription(
 MOCK_CONFIG_DATA = {
     CONF_DESCRIPTION: DEVICE_DESCRIPTION,
     CONF_HOST: "1.2.3.4",
+    CONF_MODE: "AES",
     CONF_PSK: "PSK_KEY",
     CONF_AES_IV: "AES_IV",
     CONF_DEVICE_ID: "Test_Device_ID",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -400,7 +400,7 @@ async def test_user_set_host(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "host"
-    assert result["errors"]["base"] == "cannot_connect"
+    assert result["errors"]["base"] == "cannot_connect_automatic"
 
     assert appliance.host == "Test_Brand-Test_TLS-010203040506070809"
 
@@ -480,7 +480,7 @@ async def test_user_auth_failed_ssl_error(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "host"
-    assert result["errors"]["base"] == "cannot_connect"
+    assert result["errors"]["base"] == "cannot_connect_automatic"
 
     appliance._close.assert_awaited_once()
     hass.config_entries.flow.async_abort(result["flow_id"])
@@ -554,7 +554,7 @@ async def test_user_connection_failed_timeout(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "host"
-    assert result["errors"]["base"] == "cannot_connect"
+    assert result["errors"]["base"] == "cannot_connect_automatic"
 
     appliance._close.assert_awaited_once()
     hass.config_entries.flow.async_abort(result["flow_id"])
@@ -592,7 +592,7 @@ async def test_user_connection_failed_connection_error(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "host"
-    assert result["errors"]["base"] == "cannot_connect"
+    assert result["errors"]["base"] == "cannot_connect_automatic"
 
     appliance._close.assert_awaited_once()
     hass.config_entries.flow.async_abort(result["flow_id"])
@@ -630,7 +630,7 @@ async def test_user_connection_failed_handshake_error(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "host"
-    assert result["errors"]["base"] == "cannot_connect"
+    assert result["errors"]["base"] == "cannot_connect_automatic"
 
     appliance._close.assert_awaited_once()
     hass.config_entries.flow.async_abort(result["flow_id"])

--- a/tests/test_reauth_flow.py
+++ b/tests/test_reauth_flow.py
@@ -213,7 +213,7 @@ async def test_reauth_connection_failed_timeout(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "host"
-    assert result["errors"]["base"] == "cannot_connect"
+    assert result["errors"]["base"] == "cannot_connect_automatic"
 
     appliance._close.assert_awaited_once()
     hass.config_entries.flow.async_abort(result["flow_id"])
@@ -252,7 +252,7 @@ async def test_reauth_connection_failed_connection_error(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "host"
-    assert result["errors"]["base"] == "cannot_connect"
+    assert result["errors"]["base"] == "cannot_connect_automatic"
 
     appliance._close.assert_awaited_once()
     hass.config_entries.flow.async_abort(result["flow_id"])

--- a/tests/test_reconfigure_flow.py
+++ b/tests/test_reconfigure_flow.py
@@ -107,7 +107,7 @@ async def test_reconfigure_connection_falls_back_to_manual_host(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "host"
-    assert result["errors"]["base"] == "cannot_connect"
+    assert result["errors"]["base"] == "cannot_connect_automatic"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/test_reconfigure_flow.py
+++ b/tests/test_reconfigure_flow.py
@@ -1,0 +1,242 @@
+"""Tests for the reconfigure flow."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from custom_components.homeconnect_ws import config_flow
+from custom_components.homeconnect_ws.const import (
+    CONF_AES_IV,
+    CONF_FILE,
+    CONF_MANUAL_HOST,
+    CONF_PSK,
+    DOMAIN,
+)
+from home_disconnect import ParserError
+from homeassistant.const import CONF_HOST
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from . import MockAppliance
+from .const import (
+    MOCK_AES_DEVICE_ID,
+    MOCK_AES_DEVICE_INFO,
+    MOCK_CONFIG_DATA,
+)
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock, MagicMock
+
+    import pytest
+    from homeassistant.core import HomeAssistant
+
+UPLOADED_FILE = str(uuid4())
+
+
+def _mock_entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_DATA,
+        unique_id=MOCK_AES_DEVICE_ID,
+    )
+
+
+async def test_reconfigure_menu(hass: HomeAssistant) -> None:
+    """Test the reconfigure flow shows a menu with both options."""
+    mock_config = _mock_entry()
+    mock_config.add_to_hass(hass)
+
+    result = await mock_config.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "reconfigure"
+    assert set(result["menu_options"]) == {"reconfigure_connection", "reconfigure_profile"}
+
+
+async def test_reconfigure_connection_manual(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test switching to a fixed IP-Address."""
+    appliance = MockAppliance(MOCK_AES_DEVICE_INFO)
+    monkeypatch.setattr(config_flow, "HomeAppliance", appliance)
+
+    mock_config = _mock_entry()
+    mock_config.add_to_hass(hass)
+
+    result = await mock_config.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "reconfigure_connection"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_connection"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_MANUAL_HOST: True, CONF_HOST: "10.0.0.5"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config.data[CONF_MANUAL_HOST] is True
+    assert mock_config.data[CONF_HOST] == "10.0.0.5"
+    # The rest of the entry (description, keys) is untouched.
+    assert mock_config.data[CONF_PSK] == MOCK_CONFIG_DATA[CONF_PSK]
+
+    appliance._connect.assert_awaited_once()
+    appliance._close.assert_awaited_once()
+    mock_setup_entry.assert_awaited_once()
+
+
+async def test_reconfigure_connection_auto(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test switching back to automatic mDNS discovery."""
+    appliance = MockAppliance(MOCK_AES_DEVICE_INFO)
+    monkeypatch.setattr(config_flow, "HomeAppliance", appliance)
+
+    mock_config = _mock_entry()
+    mock_config.add_to_hass(hass)
+
+    result = await mock_config.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "reconfigure_connection"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_MANUAL_HOST: False, CONF_HOST: MOCK_CONFIG_DATA[CONF_HOST]},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config.data[CONF_MANUAL_HOST] is False
+
+    mock_setup_entry.assert_awaited_once()
+
+
+async def test_reconfigure_connection_failed(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test a failed connection test falls back to the host step."""
+    appliance = MockAppliance(MOCK_AES_DEVICE_INFO)
+    monkeypatch.setattr(config_flow, "HomeAppliance", appliance)
+    appliance._connect.side_effect = TimeoutError()
+
+    mock_config = _mock_entry()
+    mock_config.add_to_hass(hass)
+
+    result = await mock_config.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "reconfigure_connection"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_MANUAL_HOST: True, CONF_HOST: "10.0.0.5"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "host"
+    assert result["errors"]["base"] == "cannot_connect"
+
+    hass.config_entries.flow.async_abort(result["flow_id"])
+    mock_setup_entry.assert_not_awaited()
+
+
+async def test_reconfigure_profile(
+    hass: HomeAssistant,
+    mock_process_profile_file: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test re-uploading a profile file refreshes description and keys."""
+    appliance = MockAppliance(MOCK_AES_DEVICE_INFO)
+    monkeypatch.setattr(config_flow, "HomeAppliance", appliance)
+
+    mock_process_profile_file.return_value[MOCK_AES_DEVICE_ID]["info"]["key"] = "New_AES_PSK_KEY"
+    mock_process_profile_file.return_value[MOCK_AES_DEVICE_ID]["info"]["iv"] = "New_AES_IV"
+
+    mock_config = _mock_entry()
+    mock_config.add_to_hass(hass)
+
+    result = await mock_config.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "reconfigure_profile"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_profile"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_FILE: UPLOADED_FILE},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config.data[CONF_PSK] == "New_AES_PSK_KEY"
+    assert mock_config.data[CONF_AES_IV] == "New_AES_IV"
+    # Host is untouched by a profile refresh.
+    assert mock_config.data[CONF_HOST] == MOCK_CONFIG_DATA[CONF_HOST]
+
+    mock_setup_entry.assert_awaited_once()
+
+
+async def test_reconfigure_profile_appliance_not_in_file(
+    hass: HomeAssistant,
+    mock_process_profile_file: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test uploading a profile file for a different Appliance aborts."""
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_DATA,
+        unique_id="other_id",
+    )
+    mock_config.add_to_hass(hass)
+
+    result = await mock_config.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "reconfigure_profile"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_FILE: UPLOADED_FILE},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "appliance_not_in_profile_file"
+    mock_setup_entry.assert_not_awaited()
+
+
+async def test_reconfigure_profile_invalid_config_parser(
+    hass: HomeAssistant,
+    mock_process_profile_file: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test a reconfigure profile upload with error in config parser."""
+    mock_config = _mock_entry()
+    mock_config.add_to_hass(hass)
+
+    mock_process_profile_file.side_effect = ParserError("Test Error")
+
+    result = await mock_config.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "reconfigure_profile"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_FILE: UPLOADED_FILE},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "profile_file_parser_error"
+    assert result["description_placeholders"] == {"error": "Test Error"}
+    mock_setup_entry.assert_not_awaited()

--- a/tests/test_reconfigure_flow.py
+++ b/tests/test_reconfigure_flow.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
 from custom_components.homeconnect_ws import config_flow
@@ -20,18 +22,20 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from . import MockAppliance
 from .const import (
+    MOCK_AES_DEVICE_DESCRIPTION,
     MOCK_AES_DEVICE_ID,
     MOCK_AES_DEVICE_INFO,
     MOCK_CONFIG_DATA,
 )
 
 if TYPE_CHECKING:
-    from unittest.mock import AsyncMock, MagicMock
+    from unittest.mock import MagicMock
 
     import pytest
     from homeassistant.core import HomeAssistant
 
 UPLOADED_FILE = str(uuid4())
+AUTO_HOST = "Fake_deviceID"  # MOCK_APPLIANCE_INFO["deviceID"], AES mode uses it as-is
 
 
 def _mock_entry() -> MockConfigEntry:
@@ -54,14 +58,45 @@ async def test_reconfigure_menu(hass: HomeAssistant) -> None:
     assert set(result["menu_options"]) == {"reconfigure_connection", "reconfigure_profile"}
 
 
-async def test_reconfigure_connection_manual(
+async def test_reconfigure_connection_auto_succeeds(
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Test switching to a fixed IP-Address."""
+    """Test that picking Change Connection tries automatic discovery first."""
     appliance = MockAppliance(MOCK_AES_DEVICE_INFO)
     monkeypatch.setattr(config_flow, "HomeAppliance", appliance)
+
+    mock_config = _mock_entry()
+    mock_config.add_to_hass(hass)
+
+    result = await mock_config.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "reconfigure_connection"}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config.data[CONF_MANUAL_HOST] is False
+    assert mock_config.data[CONF_HOST] == AUTO_HOST
+    # The rest of the entry (description, keys) is untouched.
+    assert mock_config.data[CONF_PSK] == MOCK_CONFIG_DATA[CONF_PSK]
+
+    appliance._connect.assert_awaited_once()
+    appliance._close.assert_awaited_once()
+    mock_setup_entry.assert_awaited_once()
+
+
+async def test_reconfigure_connection_falls_back_to_manual_host(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test that a failed automatic attempt falls back to asking for a fixed IP."""
+    appliance = MockAppliance(MOCK_AES_DEVICE_INFO)
+    monkeypatch.setattr(config_flow, "HomeAppliance", appliance)
+    appliance._connect.side_effect = [TimeoutError(), None]
 
     mock_config = _mock_entry()
     mock_config.add_to_hass(hass)
@@ -71,11 +106,12 @@ async def test_reconfigure_connection_manual(
         result["flow_id"], {"next_step_id": "reconfigure_connection"}
     )
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_connection"
+    assert result["step_id"] == "host"
+    assert result["errors"]["base"] == "cannot_connect"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_MANUAL_HOST: True, CONF_HOST: "10.0.0.5"},
+        user_input={CONF_HOST: "10.0.0.5"},
     )
     await hass.async_block_till_done()
 
@@ -83,39 +119,6 @@ async def test_reconfigure_connection_manual(
     assert result["reason"] == "reconfigure_successful"
     assert mock_config.data[CONF_MANUAL_HOST] is True
     assert mock_config.data[CONF_HOST] == "10.0.0.5"
-    # The rest of the entry (description, keys) is untouched.
-    assert mock_config.data[CONF_PSK] == MOCK_CONFIG_DATA[CONF_PSK]
-
-    appliance._connect.assert_awaited_once()
-    appliance._close.assert_awaited_once()
-    mock_setup_entry.assert_awaited_once()
-
-
-async def test_reconfigure_connection_auto(
-    hass: HomeAssistant,
-    monkeypatch: pytest.MonkeyPatch,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """Test switching back to automatic mDNS discovery."""
-    appliance = MockAppliance(MOCK_AES_DEVICE_INFO)
-    monkeypatch.setattr(config_flow, "HomeAppliance", appliance)
-
-    mock_config = _mock_entry()
-    mock_config.add_to_hass(hass)
-
-    result = await mock_config.start_reconfigure_flow(hass)
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"next_step_id": "reconfigure_connection"}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={CONF_MANUAL_HOST: False, CONF_HOST: MOCK_CONFIG_DATA[CONF_HOST]},
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reconfigure_successful"
-    assert mock_config.data[CONF_MANUAL_HOST] is False
 
     mock_setup_entry.assert_awaited_once()
 
@@ -125,7 +128,7 @@ async def test_reconfigure_connection_failed(
     monkeypatch: pytest.MonkeyPatch,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Test a failed connection test falls back to the host step."""
+    """Test both the automatic attempt and the manual retry failing."""
     appliance = MockAppliance(MOCK_AES_DEVICE_INFO)
     monkeypatch.setattr(config_flow, "HomeAppliance", appliance)
     appliance._connect.side_effect = TimeoutError()
@@ -139,7 +142,7 @@ async def test_reconfigure_connection_failed(
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={CONF_MANUAL_HOST: True, CONF_HOST: "10.0.0.5"},
+        user_input={CONF_HOST: "10.0.0.5"},
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -150,13 +153,13 @@ async def test_reconfigure_connection_failed(
     mock_setup_entry.assert_not_awaited()
 
 
-async def test_reconfigure_profile(
+async def test_reconfigure_profile_via_upload(
     hass: HomeAssistant,
     mock_process_profile_file: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Test re-uploading a profile file refreshes description and keys."""
+    """Test refreshing the profile via a fresh file upload."""
     appliance = MockAppliance(MOCK_AES_DEVICE_INFO)
     monkeypatch.setattr(config_flow, "HomeAppliance", appliance)
 
@@ -170,8 +173,15 @@ async def test_reconfigure_profile(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "reconfigure_profile"}
     )
-    assert result["type"] is FlowResultType.FORM
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "reconfigure_profile"
+    assert set(result["menu_options"]) == {"legacy_oauth_region", "upload"}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "upload"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "upload"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -186,6 +196,63 @@ async def test_reconfigure_profile(
     # Host is untouched by a profile refresh.
     assert mock_config.data[CONF_HOST] == MOCK_CONFIG_DATA[CONF_HOST]
 
+    mock_setup_entry.assert_awaited_once()
+
+
+async def test_reconfigure_profile_via_sign_in(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test refreshing the profile via a fresh Home Connect sign-in instead of a file."""
+    appliance = MockAppliance(MOCK_AES_DEVICE_INFO)
+    monkeypatch.setattr(config_flow, "HomeAppliance", appliance)
+    monkeypatch.setattr(
+        config_flow,
+        "legacy_async_exchange_code_for_token",
+        AsyncMock(return_value="fake_token"),
+    )
+    monkeypatch.setattr(
+        config_flow,
+        "async_fetch_appliances",
+        AsyncMock(
+            return_value={
+                MOCK_AES_DEVICE_ID: {
+                    "info": MOCK_AES_DEVICE_INFO,
+                    "description": MOCK_AES_DEVICE_DESCRIPTION,
+                }
+            }
+        ),
+    )
+
+    mock_config = _mock_entry()
+    mock_config.add_to_hass(hass)
+
+    result = await mock_config.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "reconfigure_profile"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "legacy_oauth_region"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"region": "EU"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "legacy_oauth_paste"
+
+    state = parse_qs(urlparse(result["description_placeholders"]["authorize_url"]).query)["state"][
+        0
+    ]
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"legacy_redirect_url": f"homeconnectapp://auth?code=fakecode&state={state}"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
     mock_setup_entry.assert_awaited_once()
 
 
@@ -205,6 +272,9 @@ async def test_reconfigure_profile_appliance_not_in_file(
     result = await mock_config.start_reconfigure_flow(hass)
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "reconfigure_profile"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "upload"}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -230,6 +300,9 @@ async def test_reconfigure_profile_invalid_config_parser(
     result = await mock_config.start_reconfigure_flow(hass)
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"next_step_id": "reconfigure_profile"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "upload"}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],


### PR DESCRIPTION
## Description

This add the ability to perform a reconfigure flow for 2 things.

1. change ip address/hostname. Good for if someone want s to migrate from ip connection to mdns connection and vice-versa. Also good if someone is using ip connection but it changes due to DHCP.
2. New profile file. Users can submit a profile file to update the config entry's profile file good for 2 scenarios.
      1. A new profile file gives ha info about new eneites after a software update (because it can add new stuff)
      2.  The encryption key changes after the appliance is unpaired and repaired, which means ha needs a new encryption key and profile file.
      
Chris-mc1 orignally declared the reconf flow as exempt stating "No need for reconfiguration flow." But theres no reasoning and this pr proves the fact that a reconf flow is needed for quality scale compliance.


