### PR TITLE
Feat/add oven cavity light switch

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/cooking.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/cooking.py
@@ -448,6 +448,24 @@ def generate_hood_ambient_light(appliance: HomeAppliance) -> HCLightEntityDescri
     return None
 
 
+def generate_oven_cavity_light(appliance: HomeAppliance) -> HCLightEntityDescription | None:
+    """Get oven cavity light description."""
+    if "Cooking.Oven.Setting.Light.Cavity.001.Power" not in appliance.entities:
+        return None
+
+    if "Cooking.Oven.Setting.Light.Cavity.001.Brightness" in appliance.entities:
+        return HCLightEntityDescription(
+            key="light_oven_cavity",
+            entity="Cooking.Oven.Setting.Light.Cavity.001.Power",
+            brightness_entity="Cooking.Oven.Setting.Light.Cavity.001.Brightness",
+        )
+
+    return HCLightEntityDescription(
+        key="light_oven_cavity",
+        entity="Cooking.Oven.Setting.Light.Cavity.001.Power",
+    )
+
+
 COOKING_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
     "sensor": [
         HCSensorEntityDescription(
@@ -790,7 +808,7 @@ COOKING_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             device_class=SwitchDeviceClass.SWITCH,
         ),
     ],
-    "light": [generate_hood_light, generate_hood_ambient_light],
+    "light": [generate_hood_light, generate_hood_ambient_light, generate_oven_cavity_light],
     "fan": [generate_hood_fan],
     "button": [
         HCButtonEntityDescription(

--- a/custom_components/homeconnect_ws/translations/de.json
+++ b/custom_components/homeconnect_ws/translations/de.json
@@ -3985,6 +3985,9 @@
       },
       "light_cooking_ambient_lighting": {
         "name": "Umgebungslicht"
+      },
+      "light_oven_cavity": {
+        "name": "Garraumlicht"
       }
     },
     "fan": {

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -3985,6 +3985,9 @@
       },
       "light_cooking_ambient_lighting": {
         "name": "Ambient Light"
+      },
+      "light_oven_cavity": {
+        "name": "Cavity Light"
       }
     },
     "fan": {

--- a/docs/integration/supported-functions.md
+++ b/docs/integration/supported-functions.md
@@ -96,6 +96,8 @@ Some entites are excluded from this integration on purpose, even though the Home
   - Controls/reports the telescopic rack rail
 - Brand logo display
   - Toggle whether the brand logo shows on the display
+- Cavity light
+  - Turn the oven's interior light on and off
 
 ## Hob
 


### PR DESCRIPTION
Adds a `switch_oven_cavity_light` entity for `Cooking.Oven.Setting.Light.Cavity.001.Power`
(readwrite boolean), so the oven interior light can be toggled from Home Assistant.

- Materialises only on ovens whose profile exposes that setting; no effect on any other
  appliance (additive entity description).
- `en.json` / `de.json` name strings added.
- Tested live on a Siemens oven.

Ported from Asmir1975/homeconnect_local_hass-UI@2586178.
