### PR TITLE
Stable v2 support

### DIFF
--- a/custom_components/homeconnect_ws/__init__.py
+++ b/custom_components/homeconnect_ws/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Never
 
@@ -21,9 +20,11 @@ from homeassistant.util.hass_dict import HassKey
 
 from .const import (
     CONF_APPLIANCE_INFO,
+    CONF_DESCRIPTION_FILENAME,
     CONF_DEV_OVERRIDE_HOST,
     CONF_DEV_OVERRIDE_PSK,
     CONF_DEV_SETUP_FROM_DUMP,
+    CONF_FEATURE_FILENAME,
     DOMAIN,
     PLATFORMS,
 )
@@ -31,7 +32,7 @@ from .coordinator import HomeConnectCoordinator
 from .entity_descriptions import get_available_entities
 from .export_view import HCExportView
 from .helpers import error_decorator, get_config_entry_from_call
-from .profile_storage import write_description_files
+from .profile_storage import load_description_files, remove_description_files
 
 if TYPE_CHECKING:
     from home_disconnect import HomeAppliance
@@ -182,6 +183,28 @@ async def async_setup_entry(
     config_entry: HCConfigEntry,
 ) -> bool:
     """Set up this integration using config entry."""
+    if CONF_DESCRIPTION not in config_entry.data:
+        # A v2-shaped entry (upstream chris-mc1/homeconnect_local_hass, or a
+        # previous run of this fork's now-removed v1->v2 migration) - this
+        # fork only ever speaks the older, simpler CONF_DESCRIPTION shape,
+        # so convert it down once rather than teaching the rest of the
+        # integration to understand two schemas. Triggered by data shape,
+        # not entry.version: HA hard-blocks setup entirely (before any of
+        # our code runs) if entry.version is higher than this integration's
+        # declared VERSION, so this can't be done as a migration step - it
+        # has to happen here, every time, cheaply short-circuited by the
+        # CONF_DESCRIPTION check above once an entry has been converted.
+        description = await load_description_files(hass, config_entry)
+        new_data = {
+            k: v
+            for k, v in config_entry.data.items()
+            if k not in (CONF_APPLIANCE_INFO, CONF_DESCRIPTION_FILENAME, CONF_FEATURE_FILENAME)
+        }
+        new_data[CONF_DESCRIPTION] = description
+        await remove_description_files(hass, config_entry)
+        hass.config_entries.async_update_entry(config_entry, data=new_data)
+        _LOGGER.debug("Converted %s from v2 to v1 storage", description["info"].get("vib"))
+
     _LOGGER.debug("Setting up %s", config_entry.data[CONF_DESCRIPTION]["info"].get("model"))
     coordinator = HomeConnectCoordinator(hass, config_entry)
     appliance = coordinator.appliance
@@ -238,32 +261,16 @@ async def async_unload_entry(hass: HomeAssistant, entry: HCConfigEntry) -> bool:
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: HCConfigEntry) -> bool:
     """
-    Migrate a v1 config entry to the v2 storage schema.
+    Bump an old entry's version number, without changing its data shape.
 
-    v1 stored the entire parsed description inline in the entry's own data.
-    v2 (matching upstream chris-mc1/homeconnect_local_hass's schema exactly,
-    so a future merge doesn't have to reconcile two different "v2" shapes)
-    writes it out as XML under HA's storage dir instead, keyed by device ID,
-    with just the appliance's info dict (CONF_APPLIANCE_INFO) kept on the
-    entry itself.
-
-    CONF_DESCRIPTION is deliberately kept alongside the new keys rather than
-    removed - coordinator.py still reads it directly at several points, and
-    switching it over to load from the new storage files instead is a
-    separate, larger follow-up. This migration only needs to be correct
-    about writing the v2-shaped data next to it.
+    This only ever fires for entry.version < VERSION (HA hard-blocks setup
+    entirely, before calling any of our code, when entry.version is higher
+    than declared - see async_setup_entry for how a *newer*-shaped v2 entry
+    actually gets handled). A v1 entry from before this fork declared
+    VERSION = 2 is already CONF_DESCRIPTION-shaped, which is the only shape
+    this fork ever wants - there's nothing to convert, just the number
+    itself needs to catch up so this stops being called every startup.
     """
     if config_entry.version == 1:
-        description = deepcopy(config_entry.data[CONF_DESCRIPTION])
-        new_keys = await write_description_files(hass, description["info"]["deviceID"], description)
-        hass.config_entries.async_update_entry(
-            config_entry,
-            data={
-                **config_entry.data,
-                CONF_APPLIANCE_INFO: description["info"],
-                **new_keys,
-            },
-            version=2,
-        )
-        _LOGGER.debug("Migrated %s to config entry version 2", description["info"].get("vib"))
+        hass.config_entries.async_update_entry(config_entry, version=2)
     return True

--- a/custom_components/homeconnect_ws/__init__.py
+++ b/custom_components/homeconnect_ws/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Never
 
@@ -19,6 +20,7 @@ from homeassistant.helpers.device_registry import (
 from homeassistant.util.hass_dict import HassKey
 
 from .const import (
+    CONF_APPLIANCE_INFO,
     CONF_DEV_OVERRIDE_HOST,
     CONF_DEV_OVERRIDE_PSK,
     CONF_DEV_SETUP_FROM_DUMP,
@@ -29,6 +31,7 @@ from .coordinator import HomeConnectCoordinator
 from .entity_descriptions import get_available_entities
 from .export_view import HCExportView
 from .helpers import error_decorator, get_config_entry_from_call
+from .profile_storage import write_description_files
 
 if TYPE_CHECKING:
     from home_disconnect import HomeAppliance
@@ -231,3 +234,36 @@ async def async_unload_entry(hass: HomeAssistant, entry: HCConfigEntry) -> bool:
     if unload_ok:
         await entry.runtime_data.coordinator.close()
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: HCConfigEntry) -> bool:
+    """
+    Migrate a v1 config entry to the v2 storage schema.
+
+    v1 stored the entire parsed description inline in the entry's own data.
+    v2 (matching upstream chris-mc1/homeconnect_local_hass's schema exactly,
+    so a future merge doesn't have to reconcile two different "v2" shapes)
+    writes it out as XML under HA's storage dir instead, keyed by device ID,
+    with just the appliance's info dict (CONF_APPLIANCE_INFO) kept on the
+    entry itself.
+
+    CONF_DESCRIPTION is deliberately kept alongside the new keys rather than
+    removed - coordinator.py still reads it directly at several points, and
+    switching it over to load from the new storage files instead is a
+    separate, larger follow-up. This migration only needs to be correct
+    about writing the v2-shaped data next to it.
+    """
+    if config_entry.version == 1:
+        description = deepcopy(config_entry.data[CONF_DESCRIPTION])
+        new_keys = await write_description_files(hass, description["info"]["deviceID"], description)
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data={
+                **config_entry.data,
+                CONF_APPLIANCE_INFO: description["info"],
+                **new_keys,
+            },
+            version=2,
+        )
+        _LOGGER.debug("Migrated %s to config entry version 2", description["info"].get("vib"))
+    return True

--- a/custom_components/homeconnect_ws/__init__.py
+++ b/custom_components/homeconnect_ws/__init__.py
@@ -183,17 +183,19 @@ async def async_setup_entry(
     config_entry: HCConfigEntry,
 ) -> bool:
     """Set up this integration using config entry."""
+    new_data = None
     if CONF_DESCRIPTION not in config_entry.data:
         # A v2-shaped entry (upstream chris-mc1/homeconnect_local_hass, or a
-        # previous run of this fork's now-removed v1->v2 migration) - this
-        # fork only ever speaks the older, simpler CONF_DESCRIPTION shape,
-        # so convert it down once rather than teaching the rest of the
-        # integration to understand two schemas. Triggered by data shape,
-        # not entry.version: HA hard-blocks setup entirely (before any of
-        # our code runs) if entry.version is higher than this integration's
-        # declared VERSION, so this can't be done as a migration step - it
-        # has to happen here, every time, cheaply short-circuited by the
-        # CONF_DESCRIPTION check above once an entry has been converted.
+        # previous run of this fork's own v1<->v2 conversion elsewhere) -
+        # this fork only ever speaks the older, simpler CONF_DESCRIPTION
+        # shape, so convert it down once rather than teaching the rest of
+        # the integration to understand two schemas. Triggered by data
+        # shape, not entry.version: HA hard-blocks setup entirely (before
+        # any of our code runs) if entry.version is higher than this
+        # integration's declared VERSION, so this can't be done as a
+        # migration step - it has to happen here, every time, cheaply
+        # short-circuited by the CONF_DESCRIPTION check above once an entry
+        # has been converted.
         description = await load_description_files(hass, config_entry)
         new_data = {
             k: v
@@ -202,8 +204,20 @@ async def async_setup_entry(
         }
         new_data[CONF_DESCRIPTION] = description
         await remove_description_files(hass, config_entry)
-        hass.config_entries.async_update_entry(config_entry, data=new_data)
         _LOGGER.debug("Converted %s from v2 to v1 storage", description["info"].get("vib"))
+
+    if new_data is not None or config_entry.version != 1:
+        # VERSION is declared as 2 (see config_flow.py) purely so HA
+        # doesn't hard-block an entry created by newer upstream code -
+        # every entry this fork actually touches gets stamped back down to
+        # 1 regardless, since 1 is the only version number any release of
+        # this fork has ever understood. That keeps every entry we write
+        # loadable by an older release of this fork too, not just newer
+        # ones - rolling back doesn't hit the same hard block that a
+        # genuinely higher, unrecognized version number would.
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data or config_entry.data, version=1
+        )
 
     _LOGGER.debug("Setting up %s", config_entry.data[CONF_DESCRIPTION]["info"].get("model"))
     coordinator = HomeConnectCoordinator(hass, config_entry)
@@ -259,18 +273,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: HCConfigEntry) -> bool:
     return unload_ok
 
 
-async def async_migrate_entry(hass: HomeAssistant, config_entry: HCConfigEntry) -> bool:
+async def async_migrate_entry(hass: HomeAssistant, config_entry: HCConfigEntry) -> bool:  # noqa: ARG001
     """
-    Bump an old entry's version number, without changing its data shape.
+    No-op: required by HA whenever VERSION > 1 is declared, never actually needed.
 
-    This only ever fires for entry.version < VERSION (HA hard-blocks setup
-    entirely, before calling any of our code, when entry.version is higher
-    than declared - see async_setup_entry for how a *newer*-shaped v2 entry
-    actually gets handled). A v1 entry from before this fork declared
-    VERSION = 2 is already CONF_DESCRIPTION-shaped, which is the only shape
-    this fork ever wants - there's nothing to convert, just the number
-    itself needs to catch up so this stops being called every startup.
+    VERSION = 2 exists purely so HA accepts an entry created by newer
+    upstream chris-mc1/homeconnect_local_hass code instead of hard-blocking
+    it (entry.version > declared VERSION refuses setup entirely, before
+    calling any of our code). This only ever fires for entry.version < 2,
+    i.e. a v1 entry - already CONF_DESCRIPTION-shaped, the only shape this
+    fork wants, and async_setup_entry stamps every entry it touches back
+    down to version 1 regardless (see there) rather than letting it drift
+    to 2, so there's genuinely nothing to migrate here, ever.
     """
-    if config_entry.version == 1:
-        hass.config_entries.async_update_entry(config_entry, version=2)
     return True

--- a/custom_components/homeconnect_ws/config_flow.py
+++ b/custom_components/homeconnect_ws/config_flow.py
@@ -48,6 +48,7 @@ from homeassistant.helpers.selector import (
 from . import HC_KEY, HCConfig
 from .const import (
     CONF_AES_IV,
+    CONF_APPLIANCE_INFO,
     CONF_FILE,
     CONF_MANUAL_HOST,
     CONF_PSK,
@@ -63,6 +64,7 @@ from .hc_legacy_oauth import build_authorize_url as legacy_build_authorize_url
 from .hc_legacy_oauth import extract_code_from_redirect as legacy_extract_code_from_redirect
 from .hc_legacy_oauth import generate_code_verifier as legacy_generate_code_verifier
 from .hc_legacy_oauth import generate_state as legacy_generate_state
+from .profile_storage import write_description_files
 
 CONF_LEGACY_REDIRECT_URL = "legacy_redirect_url"
 
@@ -143,6 +145,8 @@ def process_json_file(config_path: Path) -> dict[str, AppliancePayload]:
 
 class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
     """HomeConnect Config flow."""
+
+    VERSION = 2
 
     @staticmethod
     def async_get_options_flow(config_entry: HCConfigEntry) -> HCOptionsFlowHandler:
@@ -417,7 +421,14 @@ class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.reauth_entry,
                 data_updates=data,
             )
-        return self.async_create_entry(title=data[CONF_NAME], data=data)
+        description = data[CONF_DESCRIPTION]
+        new_keys = await write_description_files(
+            self.hass, description["info"]["deviceID"], description
+        )
+        return self.async_create_entry(
+            title=data[CONF_NAME],
+            data={**data, CONF_APPLIANCE_INFO: description["info"], **new_keys},
+        )
 
     async def async_step_reauth(self, user_input: dict[str, Any]) -> ConfigFlowResult:
         """Reauth flow initialized."""

--- a/custom_components/homeconnect_ws/config_flow.py
+++ b/custom_components/homeconnect_ws/config_flow.py
@@ -48,7 +48,6 @@ from homeassistant.helpers.selector import (
 from . import HC_KEY, HCConfig
 from .const import (
     CONF_AES_IV,
-    CONF_APPLIANCE_INFO,
     CONF_FILE,
     CONF_MANUAL_HOST,
     CONF_PSK,
@@ -64,7 +63,6 @@ from .hc_legacy_oauth import build_authorize_url as legacy_build_authorize_url
 from .hc_legacy_oauth import extract_code_from_redirect as legacy_extract_code_from_redirect
 from .hc_legacy_oauth import generate_code_verifier as legacy_generate_code_verifier
 from .hc_legacy_oauth import generate_state as legacy_generate_state
-from .profile_storage import write_description_files
 
 CONF_LEGACY_REDIRECT_URL = "legacy_redirect_url"
 
@@ -421,14 +419,7 @@ class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.reauth_entry,
                 data_updates=data,
             )
-        description = data[CONF_DESCRIPTION]
-        new_keys = await write_description_files(
-            self.hass, description["info"]["deviceID"], description
-        )
-        return self.async_create_entry(
-            title=data[CONF_NAME],
-            data={**data, CONF_APPLIANCE_INFO: description["info"], **new_keys},
-        )
+        return self.async_create_entry(title=data[CONF_NAME], data=data)
 
     async def async_step_reauth(self, user_input: dict[str, Any]) -> ConfigFlowResult:
         """Reauth flow initialized."""

--- a/custom_components/homeconnect_ws/const.py
+++ b/custom_components/homeconnect_ws/const.py
@@ -38,3 +38,11 @@ CONF_REGION: Final = "region"
 CONF_DEV_SETUP_FROM_DUMP: Final = "setup_from_dump_enabled"
 CONF_DEV_OVERRIDE_HOST: Final = "override_host"
 CONF_DEV_OVERRIDE_PSK: Final = "override_psk"
+
+# Matches upstream chris-mc1/homeconnect_local_hass's v2 config entry schema
+# exactly (same key strings, same storage_dir/{deviceID}/*.xml layout) so a
+# future upstream merge doesn't have to reconcile two different
+# "v2-equivalent" schemas.
+CONF_APPLIANCE_INFO: Final = "appliance_info"
+CONF_DESCRIPTION_FILENAME: Final = "description_filename"
+CONF_FEATURE_FILENAME: Final = "feature_filename"

--- a/custom_components/homeconnect_ws/profile_storage.py
+++ b/custom_components/homeconnect_ws/profile_storage.py
@@ -1,52 +1,66 @@
-"""Write a config entry's device profile into HA's storage directory (v2 config entry schema)."""
+"""
+Read a v2-shaped config entry's device profile out of HA's storage directory.
+
+This fork intentionally keeps its own config entries in the older, simpler
+"whole parsed description inline" shape (CONF_DESCRIPTION) rather than
+adopting upstream chris-mc1/homeconnect_local_hass's newer v2 schema
+(CONF_APPLIANCE_INFO + XML files under storage_dir/{deviceID}/) - this module
+exists only so a user switching to this fork with an existing v2 entry (e.g.
+created by upstream, or a previous run of this fork's own now-removed v1->v2
+migration) gets it converted back down to CONF_DESCRIPTION shape on setup,
+instead of the fork having to understand two schemas forever.
+"""
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from home_disconnect import serialize_device_description
+from home_disconnect import parse_device_description
 from homeassistant.helpers.storage import STORAGE_DIR
 
-from .const import CONF_DESCRIPTION_FILENAME, CONF_FEATURE_FILENAME, DOMAIN
+from .const import CONF_APPLIANCE_INFO, CONF_DESCRIPTION_FILENAME, CONF_FEATURE_FILENAME, DOMAIN
 
 if TYPE_CHECKING:
     from home_disconnect import DeviceDescription
     from homeassistant.core import HomeAssistant
 
-
-def _write_description_files_sync(
-    storage_dir: Path, device_id: str, description: DeviceDescription
-) -> dict[str, str]:
-    device_description_xml, feature_mapping_xml = serialize_device_description(description)
-    description_filename = f"{device_id}/DeviceDescription.xml"
-    feature_filename = f"{device_id}/FeatureMapping.xml"
-    for filename, content in (
-        (description_filename, device_description_xml),
-        (feature_filename, feature_mapping_xml),
-    ):
-        path = storage_dir / filename
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(content)
-    return {
-        CONF_DESCRIPTION_FILENAME: description_filename,
-        CONF_FEATURE_FILENAME: feature_filename,
-    }
+    from . import HCConfigEntry
 
 
-async def write_description_files(
-    hass: HomeAssistant, device_id: str, description: DeviceDescription
-) -> dict[str, str]:
-    """
-    Serialize a parsed description back to XML and write it under HA's storage dir.
+def _load_description_files_sync(
+    storage_dir: Path, config_entry: HCConfigEntry
+) -> DeviceDescription:
+    description_path = storage_dir / config_entry.data[CONF_DESCRIPTION_FILENAME]
+    feature_path = storage_dir / config_entry.data[CONF_FEATURE_FILENAME]
+    description = parse_device_description(description_path.read_text(), feature_path.read_text())
+    # The static XML doesn't carry connection-time fields like deviceID -
+    # those only ever came from the live appliance, and got stashed
+    # separately under CONF_APPLIANCE_INFO for exactly this reason.
+    description["info"].update(config_entry.data[CONF_APPLIANCE_INFO])
+    return description
 
-    Matches upstream chris-mc1/homeconnect_local_hass's v2 config entry
-    storage layout exactly (storage_dir/{deviceID}/*.xml) so a future
-    upstream merge doesn't have to reconcile two different schemas. Returns
-    the CONF_DESCRIPTION_FILENAME/CONF_FEATURE_FILENAME values to store on
-    the entry.
-    """
+
+async def load_description_files(
+    hass: HomeAssistant, config_entry: HCConfigEntry
+) -> DeviceDescription:
+    """Reconstruct a full description from a v2-shaped entry's stored XML files."""
     storage_dir = Path(hass.config.path(STORAGE_DIR, DOMAIN))
     return await hass.async_add_executor_job(
-        _write_description_files_sync, storage_dir, device_id, description
+        _load_description_files_sync, storage_dir, config_entry
     )
+
+
+def _remove_description_files_sync(storage_dir: Path, config_entry: HCConfigEntry) -> None:
+    for key in (CONF_DESCRIPTION_FILENAME, CONF_FEATURE_FILENAME):
+        with contextlib.suppress(FileNotFoundError):
+            (storage_dir / config_entry.data[key]).unlink()
+    with contextlib.suppress(FileNotFoundError, OSError):
+        (storage_dir / config_entry.data[CONF_DESCRIPTION_FILENAME]).parent.rmdir()
+
+
+async def remove_description_files(hass: HomeAssistant, config_entry: HCConfigEntry) -> None:
+    """Delete a v2 entry's now-unneeded XML files after converting it down to v1."""
+    storage_dir = Path(hass.config.path(STORAGE_DIR, DOMAIN))
+    await hass.async_add_executor_job(_remove_description_files_sync, storage_dir, config_entry)

--- a/custom_components/homeconnect_ws/profile_storage.py
+++ b/custom_components/homeconnect_ws/profile_storage.py
@@ -1,0 +1,52 @@
+"""Write a config entry's device profile into HA's storage directory (v2 config entry schema)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from home_disconnect import serialize_device_description
+from homeassistant.helpers.storage import STORAGE_DIR
+
+from .const import CONF_DESCRIPTION_FILENAME, CONF_FEATURE_FILENAME, DOMAIN
+
+if TYPE_CHECKING:
+    from home_disconnect import DeviceDescription
+    from homeassistant.core import HomeAssistant
+
+
+def _write_description_files_sync(
+    storage_dir: Path, device_id: str, description: DeviceDescription
+) -> dict[str, str]:
+    device_description_xml, feature_mapping_xml = serialize_device_description(description)
+    description_filename = f"{device_id}/DeviceDescription.xml"
+    feature_filename = f"{device_id}/FeatureMapping.xml"
+    for filename, content in (
+        (description_filename, device_description_xml),
+        (feature_filename, feature_mapping_xml),
+    ):
+        path = storage_dir / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    return {
+        CONF_DESCRIPTION_FILENAME: description_filename,
+        CONF_FEATURE_FILENAME: feature_filename,
+    }
+
+
+async def write_description_files(
+    hass: HomeAssistant, device_id: str, description: DeviceDescription
+) -> dict[str, str]:
+    """
+    Serialize a parsed description back to XML and write it under HA's storage dir.
+
+    Matches upstream chris-mc1/homeconnect_local_hass's v2 config entry
+    storage layout exactly (storage_dir/{deviceID}/*.xml) so a future
+    upstream merge doesn't have to reconcile two different schemas. Returns
+    the CONF_DESCRIPTION_FILENAME/CONF_FEATURE_FILENAME values to store on
+    the entry.
+    """
+    storage_dir = Path(hass.config.path(STORAGE_DIR, DOMAIN))
+    return await hass.async_add_executor_job(
+        _write_description_files_sync, storage_dir, device_id, description
+    )

--- a/tests/const.py
+++ b/tests/const.py
@@ -44,6 +44,7 @@ MOCK_TLS_DEVICE_ID_2 = "102030405060708090"
 MOCK_TLS_DEVICE_DESCRIPTION = {"info": {}, "MOCK_TLS_DEVICE_DESCRIPTION": None}
 MOCK_TLS_DEVICE_INFO = {
     "haId": MOCK_TLS_DEVICE_ID,
+    "deviceID": MOCK_TLS_DEVICE_ID,
     "type": "Test_TLS",
     "serialNumber": MOCK_TLS_DEVICE_ID,
     "brand": "Test_Brand",
@@ -61,6 +62,7 @@ MOCK_AES_DEVICE_ID = "101112131415161718"
 MOCK_AES_DEVICE_DESCRIPTION = {"info": {}, "MOCK_AES_DEVICE_DESCRIPTION": None}
 MOCK_AES_DEVICE_INFO = {
     "haId": MOCK_AES_DEVICE_ID,
+    "deviceID": MOCK_AES_DEVICE_ID,
     "type": "Test_AES",
     "serialNumber": MOCK_AES_DEVICE_ID,
     "brand": "Test_Brand",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -74,17 +74,19 @@ async def test_load_unload_entry(
     appliance.session.close.assert_awaited_once()
 
 
-async def test_migrate_entry_v1_bumps_version_only(
+async def test_migrate_entry_v1_is_a_noop(
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Test an old v1 entry (from before this fork declared VERSION = 2) just gets bumped.
+    Test an old v1 entry passes through async_migrate_entry completely unchanged.
 
-    This fork only ever speaks the CONF_DESCRIPTION shape - a v1 entry
-    already has that, so there's nothing to convert, just the version
-    number itself needs to catch up so async_migrate_entry stops being
-    called every startup.
+    This fork deliberately keeps every entry it touches stamped at version
+    1 forever (see async_setup_entry) for full round-trip compatibility
+    with older releases of this fork - VERSION = 2 exists purely so HA
+    accepts a newer-shaped entry from upstream instead of hard-blocking
+    it, not because this fork's own entries are meant to ever become
+    version 2.
     """
     appliance = MockAppliance(DEVICE_DESCRIPTION, "host", "mock_app", "mock_app_id", "PSK_KEY")
     appliance_mock = Mock(return_value=appliance)
@@ -102,7 +104,39 @@ async def test_migrate_entry_v1_bumps_version_only(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
-    assert entry.version == 2
+    assert entry.version == 1
+    assert entry.data == MOCK_CONFIG_DATA
+
+
+async def test_setup_stamps_a_freshly_created_v2_entry_back_to_v1(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Test a brand new entry (already CONF_DESCRIPTION-shaped, but version 2) gets restamped.
+
+    HA's own flow machinery auto-stamps a freshly created entry at
+    whatever VERSION the config flow declares (2) - this fork corrects
+    that back down to 1 on first setup, same as it does for a v2-shaped
+    entry from upstream, just without any data to convert.
+    """
+    appliance = MockAppliance(DEVICE_DESCRIPTION, "host", "mock_app", "mock_app_id", "PSK_KEY")
+    appliance_mock = Mock(return_value=appliance)
+    monkeypatch.setattr(coordinator, "HomeAppliance", appliance_mock)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_DATA,
+        unique_id=MOCK_TLS_DEVICE_ID,
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 1
     assert entry.data == MOCK_CONFIG_DATA
 
 
@@ -115,12 +149,13 @@ async def test_setup_converts_v2_entry_to_v1_shape(
 
     This fork doesn't want to understand two schemas - a v2 entry (no
     CONF_DESCRIPTION, just CONF_APPLIANCE_INFO + XML files under HA's
-    storage dir) gets converted back to CONF_DESCRIPTION shape on setup,
-    and the now-unneeded v2 files get cleaned up. Detected by data shape
-    (missing CONF_DESCRIPTION), not entry.version, since HA hard-blocks
-    setup entirely for an entry whose version is higher than this
-    integration declares - async_migrate_entry never even runs for this
-    case (confirmed live: see homeconnect_local_ws_sim_fork memory).
+    storage dir) gets converted back to CONF_DESCRIPTION shape *and*
+    restamped to version 1 on setup, and the now-unneeded v2 files get
+    cleaned up. Detected by data shape (missing CONF_DESCRIPTION), not
+    entry.version, since HA hard-blocks setup entirely for an entry whose
+    version is higher than this integration declares - async_migrate_entry
+    never even runs for this case (confirmed live: see
+    homeconnect_local_ws_sim_fork memory).
     """
     appliance = MockAppliance(DEVICE_DESCRIPTION, "host", "mock_app", "mock_app_id", "PSK_KEY")
     appliance_mock = Mock(return_value=appliance)
@@ -152,6 +187,7 @@ async def test_setup_converts_v2_entry_to_v1_shape(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 1
     assert CONF_APPLIANCE_INFO not in entry.data
     assert CONF_DESCRIPTION_FILENAME not in entry.data
     assert CONF_FEATURE_FILENAME not in entry.data

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,7 +16,7 @@ from custom_components.homeconnect_ws.const import (
     CONF_FEATURE_FILENAME,
     DOMAIN,
 )
-from home_disconnect import ConnectionFailedError, parse_device_description
+from home_disconnect import ConnectionFailedError, serialize_device_description
 from home_disconnect.testutils import MockAppliance
 from homeassistant.config_entries import SOURCE_ZEROCONF, ConfigEntryState
 from homeassistant.const import CONF_DESCRIPTION, CONF_HOST
@@ -74,20 +74,17 @@ async def test_load_unload_entry(
     appliance.session.close.assert_awaited_once()
 
 
-async def test_migrate_entry_v1_to_v2(
+async def test_migrate_entry_v1_bumps_version_only(
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Test a v1 config entry migrates to v2 storage on setup.
+    Test an old v1 entry (from before this fork declared VERSION = 2) just gets bumped.
 
-    v2 matches upstream chris-mc1/homeconnect_local_hass's schema exactly
-    (CONF_APPLIANCE_INFO + XML files under storage_dir/{deviceID}/) so a
-    future upstream merge doesn't have to reconcile two different "v2"
-    shapes. CONF_DESCRIPTION is deliberately kept alongside the new keys -
-    coordinator.py still reads it directly, and switching that over is a
-    separate follow-up - so this only checks the migration itself is
-    correct, not that the old key gets dropped.
+    This fork only ever speaks the CONF_DESCRIPTION shape - a v1 entry
+    already has that, so there's nothing to convert, just the version
+    number itself needs to catch up so async_migrate_entry stops being
+    called every startup.
     """
     appliance = MockAppliance(DEVICE_DESCRIPTION, "host", "mock_app", "mock_app_id", "PSK_KEY")
     appliance_mock = Mock(return_value=appliance)
@@ -106,25 +103,62 @@ async def test_migrate_entry_v1_to_v2(
 
     assert entry.state is ConfigEntryState.LOADED
     assert entry.version == 2
+    assert entry.data == MOCK_CONFIG_DATA
+
+
+async def test_setup_converts_v2_entry_to_v1_shape(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Test a v2-shaped entry (upstream chris-mc1/homeconnect_local_hass) converts down.
+
+    This fork doesn't want to understand two schemas - a v2 entry (no
+    CONF_DESCRIPTION, just CONF_APPLIANCE_INFO + XML files under HA's
+    storage dir) gets converted back to CONF_DESCRIPTION shape on setup,
+    and the now-unneeded v2 files get cleaned up. Detected by data shape
+    (missing CONF_DESCRIPTION), not entry.version, since HA hard-blocks
+    setup entirely for an entry whose version is higher than this
+    integration declares - async_migrate_entry never even runs for this
+    case (confirmed live: see homeconnect_local_ws_sim_fork memory).
+    """
+    appliance = MockAppliance(DEVICE_DESCRIPTION, "host", "mock_app", "mock_app_id", "PSK_KEY")
+    appliance_mock = Mock(return_value=appliance)
+    monkeypatch.setattr(coordinator, "HomeAppliance", appliance_mock)
 
     device_id = MOCK_APPLIANCE_INFO["deviceID"]
-    assert entry.data[CONF_APPLIANCE_INFO] == MOCK_APPLIANCE_INFO
-    assert entry.data[CONF_DESCRIPTION_FILENAME] == f"{device_id}/DeviceDescription.xml"
-    assert entry.data[CONF_FEATURE_FILENAME] == f"{device_id}/FeatureMapping.xml"
-    # Kept, not dropped - coordinator.py still reads this directly.
-    assert entry.data[CONF_DESCRIPTION] == DEVICE_DESCRIPTION
-
-    # Round-trip fidelity of serialize_device_description()/
-    # parse_device_description() themselves is home-disconnect's own
-    # concern (covered by its own test suite) - this only checks the
-    # migration actually wrote real, parseable XML, not that every field/
-    # entity survives serialization byte-for-byte.
     storage_dir = Path(hass.config.path(STORAGE_DIR, DOMAIN))
-    description_xml = (storage_dir / entry.data[CONF_DESCRIPTION_FILENAME]).read_text()
-    feature_xml = (storage_dir / entry.data[CONF_FEATURE_FILENAME]).read_text()
-    reloaded = parse_device_description(description_xml, feature_xml)
-    assert reloaded["status"]
-    assert reloaded["setting"]
+    description_xml, feature_xml = serialize_device_description(DEVICE_DESCRIPTION)
+    description_filename = f"{device_id}/DeviceDescription.xml"
+    feature_filename = f"{device_id}/FeatureMapping.xml"
+    (storage_dir / description_filename).parent.mkdir(parents=True, exist_ok=True)
+    (storage_dir / description_filename).write_text(description_xml)
+    (storage_dir / feature_filename).write_text(feature_xml)
+
+    v2_data = {k: v for k, v in MOCK_CONFIG_DATA.items() if k != CONF_DESCRIPTION} | {
+        CONF_APPLIANCE_INFO: MOCK_APPLIANCE_INFO,
+        CONF_DESCRIPTION_FILENAME: description_filename,
+        CONF_FEATURE_FILENAME: feature_filename,
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=v2_data,
+        unique_id=MOCK_TLS_DEVICE_ID,
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert CONF_APPLIANCE_INFO not in entry.data
+    assert CONF_DESCRIPTION_FILENAME not in entry.data
+    assert CONF_FEATURE_FILENAME not in entry.data
+    assert entry.data[CONF_DESCRIPTION]["info"]["deviceID"] == device_id
+    # The v2 files are cleaned up once converted, not left behind.
+    assert not (storage_dir / description_filename).exists()
+    assert not (storage_dir / feature_filename).exists()
 
 
 async def test_setup_entry_washer_connect_failure_is_non_blocking(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,21 +5,28 @@ from __future__ import annotations
 import asyncio
 from copy import deepcopy
 from ipaddress import ip_address
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import ANY, AsyncMock, Mock
 
 from custom_components.homeconnect_ws import coordinator
-from custom_components.homeconnect_ws.const import DOMAIN
-from home_disconnect import ConnectionFailedError
+from custom_components.homeconnect_ws.const import (
+    CONF_APPLIANCE_INFO,
+    CONF_DESCRIPTION_FILENAME,
+    CONF_FEATURE_FILENAME,
+    DOMAIN,
+)
+from home_disconnect import ConnectionFailedError, parse_device_description
 from home_disconnect.testutils import MockAppliance
 from homeassistant.config_entries import SOURCE_ZEROCONF, ConfigEntryState
 from homeassistant.const import CONF_DESCRIPTION, CONF_HOST
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from .const import DEVICE_DESCRIPTION, MOCK_CONFIG_DATA, MOCK_TLS_DEVICE_ID
+from .const import DEVICE_DESCRIPTION, MOCK_APPLIANCE_INFO, MOCK_CONFIG_DATA, MOCK_TLS_DEVICE_ID
 
 if TYPE_CHECKING:
     import pytest
@@ -65,6 +72,59 @@ async def test_load_unload_entry(
     assert entry.state is ConfigEntryState.NOT_LOADED
 
     appliance.session.close.assert_awaited_once()
+
+
+async def test_migrate_entry_v1_to_v2(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Test a v1 config entry migrates to v2 storage on setup.
+
+    v2 matches upstream chris-mc1/homeconnect_local_hass's schema exactly
+    (CONF_APPLIANCE_INFO + XML files under storage_dir/{deviceID}/) so a
+    future upstream merge doesn't have to reconcile two different "v2"
+    shapes. CONF_DESCRIPTION is deliberately kept alongside the new keys -
+    coordinator.py still reads it directly, and switching that over is a
+    separate follow-up - so this only checks the migration itself is
+    correct, not that the old key gets dropped.
+    """
+    appliance = MockAppliance(DEVICE_DESCRIPTION, "host", "mock_app", "mock_app_id", "PSK_KEY")
+    appliance_mock = Mock(return_value=appliance)
+    monkeypatch.setattr(coordinator, "HomeAppliance", appliance_mock)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_DATA,
+        unique_id=MOCK_TLS_DEVICE_ID,
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 2
+
+    device_id = MOCK_APPLIANCE_INFO["deviceID"]
+    assert entry.data[CONF_APPLIANCE_INFO] == MOCK_APPLIANCE_INFO
+    assert entry.data[CONF_DESCRIPTION_FILENAME] == f"{device_id}/DeviceDescription.xml"
+    assert entry.data[CONF_FEATURE_FILENAME] == f"{device_id}/FeatureMapping.xml"
+    # Kept, not dropped - coordinator.py still reads this directly.
+    assert entry.data[CONF_DESCRIPTION] == DEVICE_DESCRIPTION
+
+    # Round-trip fidelity of serialize_device_description()/
+    # parse_device_description() themselves is home-disconnect's own
+    # concern (covered by its own test suite) - this only checks the
+    # migration actually wrote real, parseable XML, not that every field/
+    # entity survives serialization byte-for-byte.
+    storage_dir = Path(hass.config.path(STORAGE_DIR, DOMAIN))
+    description_xml = (storage_dir / entry.data[CONF_DESCRIPTION_FILENAME]).read_text()
+    feature_xml = (storage_dir / entry.data[CONF_FEATURE_FILENAME]).read_text()
+    reloaded = parse_device_description(description_xml, feature_xml)
+    assert reloaded["status"]
+    assert reloaded["setting"]
 
 
 async def test_setup_entry_washer_connect_failure_is_non_blocking(


### PR DESCRIPTION
## Description

adds v2 support to stable read #64 for more info

## Checklist

- [ ] This has been tested against a real appliance
- [ ] If this adds/changes an entity: the `icons.json` file has been updated
- [ ] If this adds/changes an entity: the `translations/en.json` `strings.json`file had been updated (the reference locale — other languages are welcome but not required, a maintainer can fill those in)
- [ ] If this adds a new user-facing entity/feature: the [docs/integration/supported-functions.md](../docs/integration/supported-functions.md) had been updated
- [ ] If this changes how entity descriptions work: the [docs/development/entity_descriptions.md](../docs/development/entity_descriptions.md) had been updated
