### PR TITLE
Stop committing a real version to manifest.json

### DIFF
--- a/custom_components/homeconnect_ws/manifest.json
+++ b/custom_components/homeconnect_ws/manifest.json
@@ -23,7 +23,7 @@
   "requirements": [
     "home-disconnect==1.7.0b0"
   ],
-  "version": "1.7.0",
+  "version": "0.0.0",
   "zeroconf": [
     "_homeconnect._tcp.local."
   ]


### PR DESCRIPTION
## Description

`manifest.json`'s `version` field has been stuck at `1.7.0` through the entire 1.8.0 beta line - beta releases here never get a version-bump commit, unlike stable releases (which do, e.g. 1.7.0rc0/rc1/1.7.0/1.7.1).

This hasn't caused a live bug because `release.yaml` already patches the release zip's `manifest.json` from the tag at build time, and `hacs.json`'s `zip_release: true` is what makes HACS actually install from that patched zip instead of the raw repo tree. `zip_release` was only enabled on 2026-09-05, though - so anyone who installed 1.8.0b0 via HACS before that would have seen `1.7.0` instead of `1.8.0b0`.

Upstream just adopted `"version": "0.0.0"` in their own 1.0.6 release for exactly this reason (chris-mc1's own `release.yaml` has always patched the version at zip-build time - this just makes the committed value stop pretending to be meaningful). Doing the same here means there's no version to remember to bump on any future release, beta or stable.

## Checklist

- [X] This has been tested against a real appliance (N/A - no runtime behavior change, only affects the version string reported by HA/HACS)
- [ ] If this adds/changes an entity: the `icons.json` file has been updated (N/A)
- [ ] If this adds/changes an entity: the `translations/en.json`/`strings.json` file had been updated (N/A)
- [ ] If this adds a new user-facing entity/feature: docs updated (N/A)
- [ ] If this changes how entity descriptions work: docs updated (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)