### PR TITLE
Add hob favorite button trigger sensors

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/common.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/common.py
@@ -377,6 +377,18 @@ COMMON_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             value_off={"Off"},
         ),
         HCBinarySensorEntityDescription(
+            key="binary_sensor_favorite_001",
+            entity="BSH.Common.Event.Favorite.001.ExternalTrigger",
+            value_on={"Present", "Confirmed"},
+            value_off={"Off"},
+        ),
+        HCBinarySensorEntityDescription(
+            key="binary_sensor_favorite_002",
+            entity="BSH.Common.Event.Favorite.002.ExternalTrigger",
+            value_on={"Present", "Confirmed"},
+            value_off={"Off"},
+        ),
+        HCBinarySensorEntityDescription(
             key="binary_sensor_local_control_active",
             entity="BSH.Common.Status.LocalControlActive",
             entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/homeconnect_ws/translations/de.json
+++ b/custom_components/homeconnect_ws/translations/de.json
@@ -507,6 +507,12 @@
       "binary_sensor_alarm_clock_elapsed": {
         "name": "Alarm abgelaufen"
       },
+      "binary_sensor_favorite_001": {
+        "name": "Favoritentaste kurz gedrückt"
+      },
+      "binary_sensor_favorite_002": {
+        "name": "Favoritentaste lang gedrückt"
+      },
       "binary_sensor_local_control_active": {
         "name": "Lokale Bedienung aktiv"
       },

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -546,6 +546,12 @@
       "binary_sensor_alarm_clock_elapsed": {
         "name": "Alarm Clock Elapsed"
       },
+      "binary_sensor_favorite_001": {
+        "name": "Favorite short press"
+      },
+      "binary_sensor_favorite_002": {
+        "name": "Favorite long press"
+      },
       "binary_sensor_local_control_active": {
         "name": "Local Control Active"
       },


### PR DESCRIPTION
## Description

`BSH.Common.Event.Favorite.001/002.ExternalTrigger` report a hob's favorite-button short/long press as an event - same shape as the existing `AlarmClockElapsed` sensor. Only ever created when the appliance actually declares them (standard `get_available_entities` filtering).

Ported from **@Asmir1975**'s fork ([Asmir1975/homeconnect_local_hass-UI#50](https://github.com/Asmir1975/homeconnect_local_hass-UI/pull/50)), English and German translations included (matching the source PR); other languages fall back to English until filled in.

## Checklist

- [ ] This has been tested against a real appliance (not by me - ported from Asmir1975's fix, no hob with this feature available to confirm locally)
- [X] If this adds/changes an entity: the `icons.json` file has been updated (N/A, no icon needed - matches other plain event binary sensors)
- [X] If this adds/changes an entity: the `translations/en.json`/`strings.json` file had been updated
- [X] If this adds a new user-facing entity/feature: docs updated (small, self-explanatory diagnostic sensor - not called out separately in supported-functions.md, matching how similar sensors like AlarmClockElapsed are handled)
- [X] If this changes how entity descriptions work: docs updated (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)