### PR TITLE
Add fridge open door button

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/refrigeration.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/refrigeration.py
@@ -276,6 +276,11 @@ REFRIGERATION_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             entity="Refrigeration.Common.Command.Dispenser.WaterFilterReset",
             entity_category=EntityCategory.CONFIG,
         ),
+        HCButtonEntityDescription(
+            key="button_refrigerator_open_door",
+            entity="BSH.Common.Command.OpenDoor",
+            entity_registry_enabled_default=False,
+        ),
     ],
     "sensor": [
         HCSensorEntityDescription(

--- a/custom_components/homeconnect_ws/icons.json
+++ b/custom_components/homeconnect_ws/icons.json
@@ -539,6 +539,9 @@
             },
             "button_water_filter_reset": {
                 "default": "mdi:restore"
+            },
+            "button_refrigerator_open_door": {
+                "default": "mdi:door-open"
             }
         },
         "number": {

--- a/custom_components/homeconnect_ws/translations/de.json
+++ b/custom_components/homeconnect_ws/translations/de.json
@@ -4259,6 +4259,9 @@
       },
       "button_water_filter_reset": {
         "name": "Wasserfilter zurücksetzen"
+      },
+      "button_refrigerator_open_door": {
+        "name": "Tür öffnen"
       }
     },
     "number": {

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -3928,6 +3928,9 @@
       },
       "button_water_filter_reset": {
         "name": "Water filter reset"
+      },
+      "button_refrigerator_open_door": {
+        "name": "Open door"
       }
     },
     "number": {


### PR DESCRIPTION
## Description

`BSH.Common.Command.OpenDoor` triggers a fridge's own door-opener mechanism, where the appliance has one. Disabled by default, matching other one-shot appliance commands.

Ported from **@Asmir1975**'s fork - the OpenDoor half of [Asmir1975/homeconnect_local_hass-UI#48](https://github.com/Asmir1975/homeconnect_local_hass-UI/pull/48) (the door-assistant-force select half of that PR already existed here independently).

## Checklist

- [ ] This has been tested against a real appliance (not by me - ported from Asmir1975's fix, no fridge with a powered door opener available to confirm locally)
- [X] If this adds/changes an entity: the `icons.json` file has been updated
- [X] If this adds/changes an entity: the `translations/en.json`/`strings.json` file had been updated
- [X] If this adds a new user-facing entity/feature: docs updated (small, self-explanatory command button - not called out separately in supported-functions.md, matching how the existing water-filter-reset button is handled)
- [X] If this changes how entity descriptions work: docs updated (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)