### PR TITLE
Add IPv4/IPv6 address sensors

### DIFF
--- a/custom_components/homeconnect_ws/__init__.py
+++ b/custom_components/homeconnect_ws/__init__.py
@@ -13,7 +13,7 @@ from home_disconnect.entities import Access
 from home_disconnect.message import Action
 from home_disconnect.message import Message as HC_Message
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_DESCRIPTION, CONF_HOST, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_DESCRIPTION, EVENT_HOMEASSISTANT_STOP
 from homeassistant.exceptions import ConfigEntryError, ServiceValidationError
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
@@ -332,7 +332,7 @@ async def async_setup_entry(
         hw_version=appliance.info.get("hwVersion"),
         identifiers={(DOMAIN, config_entry.unique_id)},
         model=f"{appliance.info.get('type')}",
-        model_id=f"{appliance.info.get('vib')} / IP: {config_entry.data[CONF_HOST]}",
+        model_id=appliance.info.get("vib"),
         serial_number=appliance.info.get("serialNumber"),
         sw_version=appliance.info.get("swVersion"),
     )

--- a/custom_components/homeconnect_ws/coordinator.py
+++ b/custom_components/homeconnect_ws/coordinator.py
@@ -7,15 +7,17 @@ import logging
 import time
 from copy import deepcopy
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
+from aiohttp.client_exceptions import ClientConnectionResetError
 from home_disconnect import (
     AllreadyConnectedError,
     ConnectionFailedError,
     ConnectionState,
     HCHandshakeError,
     HomeAppliance,
+    NotConnectedError,
 )
 from homeassistant.const import CONF_DESCRIPTION, CONF_DEVICE_ID, CONF_HOST
 from homeassistant.exceptions import ConfigEntryError
@@ -93,6 +95,15 @@ LAUNDRY_RECONNECT_POLL_INTERVAL = timedelta(seconds=20)
 # escalated as a fault.
 EXPECTED_OFFLINE_APPLIANCE_TYPES = frozenset({"Washer", "Dryer", "WasherDryer"})
 
+# HCWiFI, and the ipv4/ipv6 address sensors, are all should_poll entities on
+# the same SCAN_INTERVAL (see sensor.py) and would otherwise each fire their
+# own /ni/info request every time that timer elapses - three round trips to
+# the appliance for what's the same data every time. A poll landing within
+# this window of the last one just reuses that result instead of issuing a
+# new request; small relative to the hourly interval, so it only collapses
+# near-simultaneous callers, not a legitimate next cycle's fetch.
+NETWORK_INFO_COALESCE_WINDOW = timedelta(seconds=5)
+
 
 class HomeConnectCoordinator(DataUpdateCoordinator[None]):
     """My custom coordinator."""
@@ -110,6 +121,9 @@ class HomeConnectCoordinator(DataUpdateCoordinator[None]):
     # shared session, tearing down the first attempt's in-progress connection
     # too. Serializes them so at most one is ever actually in flight.
     _connect_lock: asyncio.Lock
+    _network_info_lock: asyncio.Lock
+    _network_info: list[dict[str, Any]] | None = None
+    _network_info_fetched_at: float | None = None
 
     def __init__(
         self,
@@ -152,6 +166,7 @@ class HomeConnectCoordinator(DataUpdateCoordinator[None]):
         )
         self.disconnect_time = time.time()
         self._connect_lock = asyncio.Lock()
+        self._network_info_lock = asyncio.Lock()
 
     @property
     def expected_offline(self) -> bool:
@@ -375,6 +390,43 @@ class HomeConnectCoordinator(DataUpdateCoordinator[None]):
             self._async_poll_reconnect(dt_util.utcnow()),
             "homeconnect_ws nudge reconnect",
         )
+
+    async def async_get_network_info(self) -> list[dict[str, Any]] | None:
+        """
+        Get the appliance's /ni/info data, shared across the WiFi/ipv4/ipv6 sensors.
+
+        See NETWORK_INFO_COALESCE_WINDOW for why this caches at all rather than
+        just forwarding to appliance.get_network_config() every call.
+        """
+        async with self._network_info_lock:
+            now = time.time()
+            if (
+                self._network_info_fetched_at is not None
+                and now - self._network_info_fetched_at
+                < NETWORK_INFO_COALESCE_WINDOW.total_seconds()
+            ):
+                return self._network_info
+            if not self.appliance.session.connected:
+                # Entities can be added (and their immediate poll-on-add fired)
+                # before the appliance's first handshake completes - test-
+                # before-setup is exempt for this integration precisely
+                # because setup doesn't block on a successful connection.
+                # Polling here anyway crashed with a TypeError deep in
+                # home_disconnect's message-ID counter, which only gets
+                # initialized once the handshake actually finishes. Same
+                # guard covers a poll that happens to land during a later
+                # disconnect/reconnect window, not just the initial add.
+                self.logger.debug("Network info update skipped: not connected")
+                return self._network_info
+            try:
+                self._network_info = await self.appliance.get_network_config()
+            except ClientConnectionResetError:
+                self.logger.debug("Network info update failed: Connection reset")
+            except NotConnectedError:
+                self.logger.debug("Network info update failed: Not connected")
+            else:
+                self._network_info_fetched_at = now
+            return self._network_info
 
     async def _async_update_data(self) -> None:
         return None

--- a/custom_components/homeconnect_ws/entity_descriptions/__init__.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/__init__.py
@@ -88,6 +88,8 @@ def get_available_entities(appliance: HomeAppliance) -> _EntityDescriptionsType:
         "start_button": [],
         "switch": [],
         "wifi": [],
+        "ipv4": [],
+        "ipv6": [],
         "light": [],
         "fan": [],
         "update": [],

--- a/custom_components/homeconnect_ws/entity_descriptions/common.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/common.py
@@ -251,6 +251,24 @@ def generate_wifi(appliance: HomeAppliance) -> HCSensorEntityDescription:  # noq
     )
 
 
+def generate_ipv4(appliance: HomeAppliance) -> HCSensorEntityDescription:  # noqa: ARG001
+    """Get IPv4 address sensor description. Polled the same way as generate_wifi."""
+    return HCSensorEntityDescription(
+        key="sensor_ipv4_address",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    )
+
+
+def generate_ipv6(appliance: HomeAppliance) -> HCSensorEntityDescription:  # noqa: ARG001
+    """Get IPv6 address sensor description. Polled the same way as generate_wifi."""
+    return HCSensorEntityDescription(
+        key="sensor_ipv6_address",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    )
+
+
 def generate_temperature_unit(appliance: HomeAppliance) -> HCSelectEntityDescription | None:
     """Get Temperature unit description."""
     entity = appliance.entities.get("BSH.Common.Setting.TemperatureUnit")
@@ -606,6 +624,8 @@ COMMON_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
         ),
     ],
     "wifi": [generate_wifi],
+    "ipv4": [generate_ipv4],
+    "ipv6": [generate_ipv6],
     "update": [generate_software_download_update, generate_software_update],
     "dynamic": [generate_power_switch, generate_program],
 }

--- a/custom_components/homeconnect_ws/entity_descriptions/descriptions_definitions.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/descriptions_definitions.py
@@ -171,6 +171,8 @@ class EntityDescriptions(TypedDict, total=False):
     start_button: list[HCButtonEntityDescription]
     switch: list[HCSwitchEntityDescription]
     wifi: list[HCSensorEntityDescription]
+    ipv4: list[HCSensorEntityDescription]
+    ipv6: list[HCSensorEntityDescription]
     light: list[HCLightEntityDescription]
     fan: list[HCFanEntityDescription]
     update: list[HCUpdateEntityDescription]
@@ -189,6 +191,8 @@ _EntityDescriptionsDefinitionsType = dict[
         "start_button",
         "switch",
         "wifi",
+        "ipv4",
+        "ipv6",
         "light",
         "fan",
         "update",
@@ -213,6 +217,8 @@ _EntityDescriptionsType = dict[
         "start_button",
         "switch",
         "wifi",
+        "ipv4",
+        "ipv6",
         "light",
         "fan",
         "update",

--- a/custom_components/homeconnect_ws/icons.json
+++ b/custom_components/homeconnect_ws/icons.json
@@ -358,6 +358,12 @@
             "sensor_wifi_signal_strength": {
                 "default": "mdi:wifi"
             },
+            "sensor_ipv4_address": {
+                "default": "mdi:ip-network"
+            },
+            "sensor_ipv6_address": {
+                "default": "mdi:ip-network"
+            },
             "sensor_grease_filter_saturation": {
                 "default": "mdi:air-filter"
             },

--- a/custom_components/homeconnect_ws/sensor.py
+++ b/custom_components/homeconnect_ws/sensor.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from aiohttp.client_exceptions import ClientConnectionResetError
-from home_disconnect import NotConnectedError
 from homeassistant.components.sensor import SensorEntity
 
 from .entity import HCEntity
@@ -52,12 +50,14 @@ def _no_active_program_and_off(appliance: HomeAppliance) -> bool:
     return power_state is not None and power_state.value in _POWER_OFF_STATE_NAMES
 
 
-# HCWiFI is the only should_poll entity in this platform, so this interval only
-# affects it. WiFi signal strength is only available via an active /ni/info request
-# (there's no push notification for it), and the appliance is stationary, so its
-# signal has no reason to change minute-to-minute. Poll infrequently: enough to catch
-# a real degradation trend, without adding needless traffic to the appliance's
-# connection.
+# HCWiFI and the ipv4/ipv6 address sensors are the only should_poll entities in
+# this platform, so this interval only affects them. Their /ni/info data is only
+# available via an active request (there's no push notification for any of it),
+# and the appliance is stationary, so none of it has reason to change minute-to-
+# minute. Poll infrequently: enough to catch a real change/degradation trend,
+# without adding needless traffic to the appliance's connection. All three share
+# one fetch per interval rather than issuing three - see
+# coordinator.async_get_network_info.
 SCAN_INTERVAL = timedelta(hours=1)
 
 # (exclusive upper bound on |RSSI| in dBm, icon) - checked in order, first match wins.
@@ -83,6 +83,8 @@ async def async_setup_entry(
             "event_sensor": HCEventSensor,
             "active_program": HCActiveProgram,
             "wifi": HCWiFI,
+            "ipv4": HCIPv4Address,
+            "ipv6": HCIPv6Address,
         },
         config_entry.runtime_data,
     )
@@ -253,24 +255,88 @@ class HCWiFI(HCEntity, SensorEntity):
         return "mdi:wifi-strength-1-alert"
 
     async def async_update(self) -> None:
-        if not self._runtime_data.appliance.session.connected:
-            # Entities can be added (and the immediate poll below fired) before
-            # the appliance's first handshake completes - test-before-setup is
-            # exempt for this integration precisely because setup doesn't block
-            # on a successful connection. Polling here anyway crashed with a
-            # TypeError deep in home_disconnect's message-ID counter, which
-            # only gets initialized once the handshake actually finishes. Same
-            # guard covers a poll that happens to land during a later
-            # disconnect/reconnect window, not just the initial add.
-            _LOGGER.debug("WiFi update skipped: not connected")
+        network_info = await self._runtime_data.coordinator.async_get_network_info()
+        if network_info and isinstance(network_info, list) and "rssi" in network_info[0]:
+            self._attr_native_value = network_info[0]["rssi"]
+        else:
+            _LOGGER.debug("WiFi update failed: unexpected response format: %s", network_info)
+
+
+class HCIPAddress(HCEntity, SensorEntity):
+    """
+    Base for the IPv4/IPv6 address sensors.
+
+    Polled the same way as HCWiFI (see its docstring/should_poll override),
+    sharing the same /ni/info data through the coordinator's cache rather than
+    each issuing its own request - see NETWORK_INFO_COALESCE_WINDOW in
+    coordinator.py.
+    """
+
+    entity_description: HCSensorEntityDescription
+    # Set by the two concrete subclasses below - "ipV4" or "ipV6", matching
+    # the key /ni/info nests each interface's address block under.
+    _interface_key: ClassVar[str]
+
+    @property
+    def should_poll(self) -> bool:
+        # See HCWiFI.should_poll for why this override is required.
+        return True
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        # Without this, the platform's SCAN_INTERVAL timer wouldn't fire the
+        # first poll until a full interval after setup/reload - get a value
+        # immediately instead of sitting at unknown for up to an hour.
+        await self.async_update()
+        self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        # HCEntity's own extra_state_attributes builds off entity_description.
+        # extra_attributes (a real BSH entity's value) - these sensors have no
+        # backing BSH entity at all, so that machinery doesn't apply here.
+        return self._address_attributes
+
+    def __init__(
+        self,
+        entity_description: HCSensorEntityDescription,
+        runtime_data: HCData,
+    ) -> None:
+        super().__init__(entity_description, runtime_data)
+        self._address_attributes: dict[str, Any] = {}
+
+    async def async_update(self) -> None:
+        network_info = await self._runtime_data.coordinator.async_get_network_info()
+        if not network_info or not isinstance(network_info, list):
+            _LOGGER.debug(
+                "%s update failed: unexpected response format: %s",
+                self.entity_description.key,
+                network_info,
+            )
             return
-        try:
-            network_info = await self._runtime_data.appliance.get_network_config()
-            if network_info and isinstance(network_info, list) and "rssi" in network_info[0]:
-                self._attr_native_value = network_info[0]["rssi"]
-            else:
-                _LOGGER.debug("WiFi update failed: unexpected response format: %s", network_info)
-        except ClientConnectionResetError:
-            _LOGGER.debug("WiFi update failed: Connection reset")
-        except NotConnectedError:
-            _LOGGER.debug("WiFi update failed: Not connected")
+        address_info = network_info[0].get(self._interface_key)
+        if not isinstance(address_info, dict):
+            # Normal, not an error: an appliance with only an IPv4 or only an
+            # IPv6 address simply won't have the other key in its /ni/info
+            # response at all.
+            self._attr_native_value = None
+            self._address_attributes = {}
+            return
+        self._attr_native_value = address_info.get("ipAddress")
+        self._address_attributes = {
+            "prefix_size": address_info.get("prefixSize"),
+            "gateway": address_info.get("gateway"),
+            "dns_server": address_info.get("dnsServer"),
+        }
+
+
+class HCIPv4Address(HCIPAddress):
+    """IPv4 address Sensor Entity."""
+
+    _interface_key = "ipV4"
+
+
+class HCIPv6Address(HCIPAddress):
+    """IPv6 address Sensor Entity."""
+
+    _interface_key = "ipV6"

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -1853,6 +1853,12 @@
       "sensor_wifi_signal_strength": {
         "name": "WiFi Signal strength"
       },
+      "sensor_ipv4_address": {
+        "name": "IPv4 address"
+      },
+      "sensor_ipv6_address": {
+        "name": "IPv6 address"
+      },
       "sensor_grease_filter_saturation": {
         "name": "Grease Filter Saturation"
       },

--- a/docs/integration/supported-functions.md
+++ b/docs/integration/supported-functions.md
@@ -26,7 +26,7 @@ The following entities are available. Which ones appear depends on the appliance
 | Software Update | Update | Tracks/triggers installing an available firmware update |
 | Software Download | Update | Tracks/triggers downloading an available firmware update (only on appliances that support a separate download stage) |
 
-A few additional diagnostic entities (Local Control Active, Remote Control Active) are also available, disabled by default.
+A few additional diagnostic entities (Local Control Active, Remote Control Active, IPv4 Address, IPv6 Address) are also available, disabled by default. The IPv4/IPv6 Address sensors are polled the same way as Wi-Fi Signal Strength above, and carry the subnet prefix size, gateway, and DNS server as attributes.
 
 The Home Connect protocol only signals that a firmware update exists, not which version it is, so the Update entities show a generic "New Version" placeholder rather than a real version number when one is available. Also, as mentioned before, if you disabled cloud access for your appliance, or it cannot reach the Home Connect Cloud, then it cannot get new firmware updates.
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,102 @@
+"""Tests for HomeConnectCoordinator."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from custom_components.homeconnect_ws.const import DOMAIN
+from home_disconnect.message import Message
+
+from . import setup_config_entry
+from .const import MOCK_CONFIG_DATA
+
+if TYPE_CHECKING:
+    from home_disconnect.testutils import MockAppliance
+    from homeassistant.core import HomeAssistant
+
+_SAMPLE_NETWORK_INFO = [
+    {
+        "interfaceID": 0,
+        "type": "WiFi",
+        "rssi": -73,
+        "ipV4": {
+            "ipAddress": "192.168.1.50",
+            "prefixSize": 24,
+            "gateway": "192.168.1.1",
+            "dnsServer": "192.168.1.1",
+        },
+    }
+]
+
+
+async def test_async_get_network_info_skips_when_not_connected(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,
+) -> None:
+    """
+    Must not attempt a request before the appliance has connected.
+
+    Entities can be added (and their immediate poll-on-add fired) before the
+    appliance's first handshake completes, since setup doesn't block on a
+    successful connection. Polling anyway used to crash deep in
+    home_disconnect's message-ID counter, which is only initialized once the
+    handshake finishes - this guard is what HCWiFI's async_update used to do
+    itself before the ipv4/ipv6 sensors needed to share it too.
+    """
+    assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    mock_appliance.session.connected = False
+    mock_appliance.session.send_sync.reset_mock()
+
+    result = await entry.runtime_data.coordinator.async_get_network_info()
+
+    assert result is None
+    mock_appliance.session.send_sync.assert_not_called()
+
+
+async def test_async_get_network_info_fetches_once_connected(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,
+) -> None:
+    """Returns whatever /ni/info responds with once connected."""
+    assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    mock_appliance.session.send_sync.reset_mock()
+    mock_appliance.session.send_sync.return_value = Message(
+        resource="/ni/info", data=_SAMPLE_NETWORK_INFO
+    )
+
+    result = await entry.runtime_data.coordinator.async_get_network_info()
+
+    assert result == _SAMPLE_NETWORK_INFO
+
+
+async def test_async_get_network_info_coalesces_concurrent_calls(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,
+) -> None:
+    """
+    A second call shortly after the first reuses its result, not a new request.
+
+    HCWiFI and the ipv4/ipv6 address sensors are all should_poll entities on
+    the same SCAN_INTERVAL, so they'd otherwise each fire their own /ni/info
+    request every time that timer elapses - this is what actually collapses
+    those three into one round trip to the appliance.
+    """
+    assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    mock_appliance.session.send_sync.reset_mock()
+    mock_appliance.session.send_sync.return_value = Message(
+        resource="/ni/info", data=_SAMPLE_NETWORK_INFO
+    )
+    coordinator = entry.runtime_data.coordinator
+
+    first = await coordinator.async_get_network_info()
+    mock_appliance.session.send_sync.reset_mock()
+    second = await coordinator.async_get_network_info()
+
+    assert first == second == _SAMPLE_NETWORK_INFO
+    mock_appliance.session.send_sync.assert_not_called()

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -587,6 +587,8 @@ TRANSLATION_DOMAINS = {
     "switch": "switch",
     "update": "update",
     "wifi": "sensor",
+    "ipv4": "sensor",
+    "ipv6": "sensor",
 }
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.homeconnect_ws import HCData
 from custom_components.homeconnect_ws.entity_descriptions.descriptions_definitions import (
     HCSensorEntityDescription,
 )
-from custom_components.homeconnect_ws.sensor import HCActiveProgram, HCSensor, HCWiFI
+from custom_components.homeconnect_ws.sensor import (
+    HCActiveProgram,
+    HCIPv4Address,
+    HCIPv6Address,
+    HCSensor,
+    HCWiFI,
+)
 from homeassistant.components.sensor import ATTR_OPTIONS
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.helpers.entity import Entity as HAEntity
@@ -200,24 +206,24 @@ async def test_update_active_program(
     assert state.state == "Named Favorite"
 
 
-async def test_wifi_update_skips_when_not_connected() -> None:
+async def test_wifi_update_handles_no_network_info() -> None:
     """
-    WiFi polling must not attempt a request before the appliance has connected.
+    WiFi update must not crash when the coordinator has nothing to give it yet.
 
-    Entities can be added (and HCWiFI's immediate poll-on-add fired) before the
-    appliance's first handshake completes, since setup doesn't block on a
-    successful connection. Polling anyway used to crash deep in
-    home_disconnect's message-ID counter, which is only initialized once the
-    handshake finishes.
+    The not-connected/not-yet-fetched case itself is handled by
+    HomeConnectCoordinator.async_get_network_info (see test_coordinator.py) -
+    this only checks that HCWiFI copes with that method returning None, e.g.
+    before the appliance's first handshake completes.
     """
     appliance = MagicMock()
     appliance.info = {"deviceID": "test_device_id"}
-    appliance.session.connected = False
+    coordinator = MagicMock()
+    coordinator.async_get_network_info = AsyncMock(return_value=None)
     runtime_data = HCData(
         appliance=appliance,
         device_info=MagicMock(),
         available_entity_descriptions=MagicMock(),
-        coordinator=MagicMock(),
+        coordinator=coordinator,
     )
     entity_description = HCSensorEntityDescription(key="sensor_wifi_signal_strength")
     entity = HCWiFI(entity_description, runtime_data)
@@ -225,7 +231,63 @@ async def test_wifi_update_skips_when_not_connected() -> None:
     await entity.async_update()
 
     assert entity.native_value is None
-    appliance.get_network_config.assert_not_called()
+
+
+async def test_ipv4_address_update() -> None:
+    """The ipv4 sensor reads ipV4.ipAddress and exposes the rest as attributes."""
+    appliance = MagicMock()
+    appliance.info = {"deviceID": "test_device_id"}
+    coordinator = MagicMock()
+    coordinator.async_get_network_info = AsyncMock(
+        return_value=[
+            {
+                "ipV4": {
+                    "ipAddress": "192.168.1.50",
+                    "prefixSize": 24,
+                    "gateway": "192.168.1.1",
+                    "dnsServer": "192.168.1.1",
+                }
+            }
+        ]
+    )
+    runtime_data = HCData(
+        appliance=appliance,
+        device_info=MagicMock(),
+        available_entity_descriptions=MagicMock(),
+        coordinator=coordinator,
+    )
+    entity_description = HCSensorEntityDescription(key="sensor_ipv4_address")
+    entity = HCIPv4Address(entity_description, runtime_data)
+
+    await entity.async_update()
+
+    assert entity.native_value == "192.168.1.50"
+    assert entity.extra_state_attributes == {
+        "prefix_size": 24,
+        "gateway": "192.168.1.1",
+        "dns_server": "192.168.1.1",
+    }
+
+
+async def test_ipv6_address_update_missing_interface() -> None:
+    """An appliance with no IPv6 address just clears the sensor, not an error."""
+    appliance = MagicMock()
+    appliance.info = {"deviceID": "test_device_id"}
+    coordinator = MagicMock()
+    coordinator.async_get_network_info = AsyncMock(return_value=[{"ipV4": {"ipAddress": "x"}}])
+    runtime_data = HCData(
+        appliance=appliance,
+        device_info=MagicMock(),
+        available_entity_descriptions=MagicMock(),
+        coordinator=coordinator,
+    )
+    entity_description = HCSensorEntityDescription(key="sensor_ipv6_address")
+    entity = HCIPv6Address(entity_description, runtime_data)
+
+    await entity.async_update()
+
+    assert entity.native_value is None
+    assert entity.extra_state_attributes == {}
 
 
 async def test_native_value_cleared_when_expected_offline() -> None:


### PR DESCRIPTION
## Description

Adds two diagnostic sensors, `sensor_ipv4_address` and `sensor_ipv6_address`, reading the appliance's live address from `/ni/info` (`ipV4.ipAddress`/`ipV6.ipAddress`), with `prefix_size`, `gateway`, and `dns_server` as attributes. Both disabled by default, matching the existing WiFi signal strength sensor.

They share the WiFi sensor's hourly poll of `/ni/info` through a new `HomeConnectCoordinator.async_get_network_info()` cache instead of each entity issuing its own request - previously only the WiFi sensor polled this, now three entities do, so this collapses concurrent polls (a 5s coalescing window) into one request per cycle rather than three.

Also removes the `" / IP: <host>"` suffix PR #57 added to `model_id` on the device page. `config_entry`'s `CONF_HOST` isn't reliably an IP address at all (TLS-mode entries default it to a `brand-type-haId` hostname, only becoming a real IP if the user manually typed one in) - the new ipv4 sensor is the correct, live-polled source for this now.

## Checklist

- [ ] This has been tested against a real appliance (verified against the `hc-ws-sim` dev simulator, not yet a real appliance - these entities are disabled by default, so this is low-risk to merge before that confirmation, but flagging it explicitly)
- [X] If this adds/changes an entity: the `icons.json` file has been updated
- [X] If this adds/changes an entity: the `translations/en.json`/`strings.json` file had been updated
- [X] If this adds a new user-facing entity/feature: the docs/integration/supported-functions.md had been updated
- [ ] If this changes how entity descriptions work: docs/development/entity_descriptions.md had been updated (N/A, no change to how descriptions work, just two new always-available generic ones following the existing `wifi` pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)